### PR TITLE
Implement shame engine and API trigger

### DIFF
--- a/backend/core/urls.py
+++ b/backend/core/urls.py
@@ -1,10 +1,12 @@
 from rest_framework.routers import DefaultRouter
+from django.urls import path
 from .views import (
     UserViewSet,
     ProfileViewSet,
     DailyLockoutViewSet,
     ShamePostViewSet,
     PaddleLogViewSet,
+    trigger_shame_view,
 )
 
 router = DefaultRouter()
@@ -14,4 +16,6 @@ router.register(r'lockouts', DailyLockoutViewSet)
 router.register(r'shame-posts', ShamePostViewSet)
 router.register(r'paddle-logs', PaddleLogViewSet)
 
-urlpatterns = router.urls
+urlpatterns = router.urls + [
+    path("trigger-shame/", trigger_shame_view),
+]

--- a/backend/core/utils/shame_engine.py
+++ b/backend/core/utils/shame_engine.py
@@ -1,0 +1,37 @@
+import random
+from django.utils import timezone
+from ..models import DailyLockout, ShamePost
+
+
+def generate_donkey_caption(user):
+    captions = [
+        f"{user.username} chose sloth over glory.",
+        f"{user.username} is now eligible for the Couch Potato Championship.",
+        f"No steps, no honor, {user.username}.",
+        "The donkey saw your laziness. It wept.",
+    ]
+    return random.choice(captions)
+
+
+def generate_donkey_image():
+    # Replace later with image gen logic
+    return "https://example.com/shameful_donkey_placeholder.jpg"
+
+
+def check_and_trigger_shame(user):
+    today = timezone.now().date()
+    lockout = DailyLockout.objects.filter(user=user, date=today).first()
+    if not lockout or lockout.is_unlocked:
+        return None
+
+    caption = generate_donkey_caption(user)
+    image_url = generate_donkey_image()
+
+    return ShamePost.objects.create(
+        user=user,
+        date=today,
+        caption=caption,
+        image_url=image_url,
+        posted_to=[],
+        was_triggered=True,
+    )

--- a/backend/core/views.py
+++ b/backend/core/views.py
@@ -1,5 +1,10 @@
 from rest_framework import viewsets
 from django.contrib.auth.models import User
+from rest_framework.decorators import api_view, permission_classes
+from rest_framework.permissions import IsAuthenticated
+from rest_framework.response import Response
+
+from .utils.shame_engine import check_and_trigger_shame
 
 from .models import Profile, DailyLockout, ShamePost, PaddleLog
 from .serializers import (
@@ -34,3 +39,16 @@ class ShamePostViewSet(viewsets.ModelViewSet):
 class PaddleLogViewSet(viewsets.ModelViewSet):
     queryset = PaddleLog.objects.all()
     serializer_class = PaddleLogSerializer
+
+
+@api_view(["POST"])
+@permission_classes([IsAuthenticated])
+def trigger_shame_view(request):
+    post = check_and_trigger_shame(request.user)
+    if not post:
+        return Response({"message": "No shame triggered. You're safe... for now."}, status=200)
+    return Response({
+        "message": "Shame post created.",
+        "caption": post.caption,
+        "image_url": post.image_url,
+    })


### PR DESCRIPTION
## Summary
- add `shame_engine` utility module with donkey caption/image logic
- expose `trigger_shame_view` API endpoint
- wire endpoint into `core/urls.py`

## Testing
- `python manage.py test`

------
https://chatgpt.com/codex/tasks/task_e_6850791704c08323b09d50b15fdfaa18