### PR TITLE
Integrate OpenAI client SDK for voice journal helpers

### DIFF
--- a/backend/core/utils/voice_helpers.py
+++ b/backend/core/utils/voice_helpers.py
@@ -1,11 +1,42 @@
-from typing import Any
+"""Helpers for working with voice journals using the OpenAI SDK."""
+
+# NOTE: This file uses the OpenAI v1 SDK (client-based). Do not revert to old ChatCompletion or Audio.transcribe calls.
+
+from openai import OpenAI
+import os
+
+
+client = OpenAI(api_key=os.getenv("OPENAI_API_KEY"))
 
 
 def transcribe_audio(file_path: str) -> str:
-    """Return a placeholder transcription for now."""
-    return "Transcription placeholder for " + file_path
+    """Transcribe the given audio file using OpenAI Whisper."""
+
+    with open(file_path, "rb") as audio_file:
+        response = client.audio.transcriptions.create(
+            model="whisper-1",
+            file=audio_file,
+        )
+        return response.text
 
 
 def summarize_text(text: str) -> str:
-    """Return a placeholder summary for now."""
-    return "Summary placeholder"
+    """Summarize a piece of text using GPT-4."""
+
+    prompt = (
+        "Summarize the following voice journal in 2-3 sentences:\n\n" + text
+    )
+
+    response = client.chat.completions.create(
+        model="gpt-4-0125-preview",
+        messages=[
+            {
+                "role": "system",
+                "content": "You're a helpful assistant who reflects on human thoughts.",
+            },
+            {"role": "user", "content": prompt},
+        ],
+        temperature=0.7,
+    )
+
+    return response.choices[0].message.content.strip()


### PR DESCRIPTION
## Summary
- switch to OpenAI v1 client SDK in `voice_helpers`
- implement real `transcribe_audio` and `summarize_text`

## Testing
- `pip install -r backend/requirements.txt`
- `python manage.py test`

------
https://chatgpt.com/codex/tasks/task_e_68508a0d4b1c8323a3e7f330045c0762