### PR TITLE
Add dashboard feed API

### DIFF
--- a/backend/core/urls.py
+++ b/backend/core/urls.py
@@ -12,6 +12,7 @@ from .views import (
     join_herd,
     leave_herd,
     my_herd,
+    dashboard_feed,
 )
 
 router = DefaultRouter()
@@ -28,4 +29,5 @@ urlpatterns = router.urls + [
     path("join-herd/", join_herd),
     path("leave-herd/", leave_herd),
     path("my-herd/", my_herd),
+    path("dashboard/", dashboard_feed),
 ]


### PR DESCRIPTION
## Summary
- add `dashboard_feed` endpoint to core app
- wire up route `/api/core/dashboard/`
- support filtering by user, herd, type and pagination

## Testing
- `pip install -r requirements.txt`
- `python manage.py test`

------
https://chatgpt.com/codex/tasks/task_e_685096a8417c8323997edeed5b8ff82f