### PR TITLE
Implement mood avatar view

### DIFF
--- a/backend/core/urls.py
+++ b/backend/core/urls.py
@@ -14,6 +14,7 @@ from .views import (
     my_herd,
     dashboard_feed,
     update_mood,
+    get_mood_avatar_view,
 )
 
 router = DefaultRouter()
@@ -32,4 +33,5 @@ urlpatterns = router.urls + [
     path("my-herd/", my_herd),
     path("dashboard/", dashboard_feed),
     path("update-mood/", update_mood),
+    path("mood-avatar/", get_mood_avatar_view),
 ]

--- a/backend/core/utils/mood_avatar.py
+++ b/backend/core/utils/mood_avatar.py
@@ -1,0 +1,14 @@
+MOOD_EMOJIS = {
+    "ashamed": "😔🫏",
+    "hype": "🔥🫏",
+    "neutral": "😐🫏",
+    "thoughtful": "🤔🫏",
+    "annoyed": "😒🫏",
+    "playful": "😜🫏",
+    "burned out": "💀🫏",
+}
+
+
+def get_mood_avatar(mood):
+    """Return the avatar (emoji) for a given mood."""
+    return MOOD_EMOJIS.get(mood, "😐🫏")

--- a/backend/core/views.py
+++ b/backend/core/views.py
@@ -16,6 +16,7 @@ from .utils.voice_helpers import (
 )
 from .utils.tts_helpers import text_to_speech
 from .utils.mood_engine import evaluate_user_mood
+from .utils.mood_avatar import get_mood_avatar
 import uuid
 
 
@@ -260,3 +261,12 @@ def update_mood(request):
     profile.mood_last_updated = timezone.now()
     profile.save()
     return Response({"mood": mood})
+
+
+@api_view(["GET"])
+@permission_classes([IsAuthenticated])
+def get_mood_avatar_view(request):
+    """Return the user's current mood and corresponding avatar."""
+    mood = request.user.profile.current_mood
+    avatar = get_mood_avatar(mood)
+    return Response({"mood": mood, "avatar": avatar})


### PR DESCRIPTION
## Summary
- map moods to donkey emoji avatars
- expose mood avatar via `/api/core/mood-avatar/`

## Testing
- `pip install -q -r requirements.txt`
- `pip install -q python-dotenv`
- `python manage.py check`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68509c2e93208323bcd94424984c6e3c