### PR TITLE
Add Donkey Daily Digest endpoint

### DIFF
--- a/backend/core/urls.py
+++ b/backend/core/urls.py
@@ -15,6 +15,7 @@ from .views import (
     dashboard_feed,
     update_mood,
     get_mood_avatar_view,
+    daily_digest,
 )
 
 router = DefaultRouter()
@@ -34,4 +35,5 @@ urlpatterns = router.urls + [
     path("dashboard/", dashboard_feed),
     path("update-mood/", update_mood),
     path("mood-avatar/", get_mood_avatar_view),
+    path("daily-digest/", daily_digest),
 ]

--- a/backend/core/utils/digest_engine.py
+++ b/backend/core/utils/digest_engine.py
@@ -1,0 +1,50 @@
+from datetime import timedelta
+from django.utils import timezone
+
+from ..models import ShamePost, VoiceJournal, DailyLockout
+from content.models import GeneratedMeme
+from .mood_engine import evaluate_user_mood
+
+
+def generate_daily_digest(user):
+    """Return a summary of the user's activity over the last 24 hours."""
+
+    now = timezone.now()
+    since = now - timedelta(hours=24)
+
+    shame_count = ShamePost.objects.filter(user=user, date__gte=since.date()).count()
+    meme_count = GeneratedMeme.objects.filter(user=user, created_at__gte=since).count()
+    journal_count = VoiceJournal.objects.filter(user=user, created_at__gte=since).count()
+    lockout = DailyLockout.objects.filter(user=user, date=since.date()).first()
+
+    herd = user.herds.first()
+    herd_name = herd.name if herd else "No herd"
+    herd_size = herd.members.count() if herd else 0
+
+    mood = evaluate_user_mood(user)
+
+    if lockout and lockout.is_unlocked:
+        tone = "positive"
+    elif shame_count:
+        tone = "ashamed"
+    else:
+        tone = "neutral"
+
+    lines = [f"\U0001F434 Donkey Daily Digest for {user.username}"]
+    lines.append(f"Mood: {mood}")
+    lines.append(f"Herd: {herd_name} ({herd_size} members)")
+    lines.append(
+        f"Movement: {'\u2714\ufe0f Completed' if lockout and lockout.is_unlocked else '\u274c Skipped'}"
+    )
+    lines.append(f"Shames: {shame_count}")
+    lines.append(f"Memes Created: {meme_count}")
+    lines.append(f"Voice Journals: {journal_count}")
+
+    if tone == "ashamed":
+        lines.append("The donkey is not mad. Just disappointed. Again.")
+    elif tone == "positive":
+        lines.append("You moved your ass. The donkey is proud. \U0001F9AF\U0001F525")
+    else:
+        lines.append("Today was… a day. The donkey remains neutral.")
+
+    return "\n".join(lines)

--- a/backend/core/views.py
+++ b/backend/core/views.py
@@ -17,6 +17,7 @@ from .utils.voice_helpers import (
 from .utils.tts_helpers import text_to_speech
 from .utils.mood_engine import evaluate_user_mood
 from .utils.mood_avatar import get_mood_avatar
+from .utils.digest_engine import generate_daily_digest
 import uuid
 
 
@@ -270,3 +271,11 @@ def get_mood_avatar_view(request):
     mood = request.user.profile.current_mood
     avatar = get_mood_avatar(mood)
     return Response({"mood": mood, "avatar": avatar})
+
+
+@api_view(["GET"])
+@permission_classes([IsAuthenticated])
+def daily_digest(request):
+    """Return a 24-hour activity summary for the authenticated user."""
+    digest = generate_daily_digest(request.user)
+    return Response({"digest": digest})


### PR DESCRIPTION
## Summary
- generate digest text for the past 24 hours
- expose `daily-digest/` API endpoint

## Testing
- `python manage.py test`
- `python manage.py shell` to call `daily_digest` endpoint via APIRequestFactory

------
https://chatgpt.com/codex/tasks/task_e_68509dc49e70832394e1b3ced71df7c9