### PR TITLE
Add weekly recap generator

### DIFF
--- a/backend/core/urls.py
+++ b/backend/core/urls.py
@@ -15,6 +15,7 @@ from .views import (
     dashboard_feed,
     update_mood,
     get_mood_avatar_view,
+    weekly_recap,
 )
 
 router = DefaultRouter()
@@ -34,4 +35,5 @@ urlpatterns = router.urls + [
     path("dashboard/", dashboard_feed),
     path("update-mood/", update_mood),
     path("mood-avatar/", get_mood_avatar_view),
+    path("weekly-recap/", weekly_recap),
 ]

--- a/backend/core/utils/recap_engine.py
+++ b/backend/core/utils/recap_engine.py
@@ -1,0 +1,60 @@
+from datetime import timedelta
+from django.utils import timezone
+from core.models import ShamePost, VoiceJournal, DailyLockout
+from content.models import GeneratedMeme
+
+
+def generate_weekly_recap(user):
+    """Return a textual recap of the user's activity in the last 7 days."""
+    now = timezone.now()
+    week_ago = now - timedelta(days=7)
+
+    lockouts = DailyLockout.objects.filter(user=user, date__gte=week_ago.date())
+    unlocked_days = sum(1 for l in lockouts if l.is_unlocked)
+
+    shames = ShamePost.objects.filter(user=user, date__gte=week_ago.date()).count()
+    memes = GeneratedMeme.objects.filter(user=user, created_at__gte=week_ago).count()
+    journals = VoiceJournal.objects.filter(user=user, created_at__gte=week_ago)
+
+    total_days = 7
+    journal_tags = {}
+    for journal in journals:
+        for tag in journal.tags or []:
+            journal_tags[tag] = journal_tags.get(tag, 0) + 1
+
+    # Tone logic
+    if unlocked_days >= 5:
+        tone = "legend"
+    elif unlocked_days >= 3:
+        tone = "resilient"
+    elif shames >= 5:
+        tone = "struggling"
+    else:
+        tone = "neutral"
+
+    lines = [
+        f"\U0001f434 Weekly Recap for {user.username}",
+        f"You moved your ass {unlocked_days}/{total_days} days this week.",
+        f"Shame Posts: {shames}",
+        f"Memes Created: {memes}",
+        f"Voice Journals: {len(journals)}",
+        (
+            "Top Journal Tags: "
+            + (
+                ", ".join(f"{k} ({v})" for k, v in journal_tags.items())
+                if journal_tags
+                else "None"
+            )
+        ),
+    ]
+
+    if tone == "legend":
+        lines.append("This donkey salutes you. You’ve earned a badge in badassery. \U0001f3c6\U0001f9a4")
+    elif tone == "resilient":
+        lines.append("You had your off days, but you kept moving. The donkey sees the grind.")
+    elif tone == "struggling":
+        lines.append("The donkey sighs. We’re not mad — just dramatically disappointed.")
+    else:
+        lines.append("It was a week. Next one’s yours.")
+
+    return "\n".join(lines)

--- a/backend/core/views.py
+++ b/backend/core/views.py
@@ -17,6 +17,7 @@ from .utils.voice_helpers import (
 from .utils.tts_helpers import text_to_speech
 from .utils.mood_engine import evaluate_user_mood
 from .utils.mood_avatar import get_mood_avatar
+from .utils.recap_engine import generate_weekly_recap
 import uuid
 
 
@@ -270,3 +271,11 @@ def get_mood_avatar_view(request):
     mood = request.user.profile.current_mood
     avatar = get_mood_avatar(mood)
     return Response({"mood": mood, "avatar": avatar})
+
+
+@api_view(["GET"])
+@permission_classes([IsAuthenticated])
+def weekly_recap(request):
+    """Return a weekly activity recap for the authenticated user."""
+    recap = generate_weekly_recap(request.user)
+    return Response({"recap": recap})


### PR DESCRIPTION
## Summary
- implement donkey-themed weekly recap logic
- expose a weekly recap API endpoint

## Testing
- `pip install -r requirements.txt`
- `python manage.py test` *(fails: OPENAI_API_KEY missing)*

------
https://chatgpt.com/codex/tasks/task_e_68509e2110708323b6bd07a058a3e68c