### PR TITLE
Add HerdMood evaluator and API

### DIFF
--- a/backend/core/urls.py
+++ b/backend/core/urls.py
@@ -15,6 +15,7 @@ from .views import (
     dashboard_feed,
     update_mood,
     get_mood_avatar_view,
+    herd_mood_view,
 )
 
 router = DefaultRouter()
@@ -34,4 +35,5 @@ urlpatterns = router.urls + [
     path("dashboard/", dashboard_feed),
     path("update-mood/", update_mood),
     path("mood-avatar/", get_mood_avatar_view),
+    path("herd-mood/", herd_mood_view),
 ]

--- a/backend/core/utils/herdmood_engine.py
+++ b/backend/core/utils/herdmood_engine.py
@@ -1,0 +1,49 @@
+from datetime import timedelta
+from django.utils import timezone
+
+from core.models import DailyLockout, ShamePost, Profile, Herd
+
+
+POSITIVE_MOODS = {"hype", "playful", "thoughtful"}
+NEGATIVE_MOODS = {"annoyed", "ashamed", "burned out"}
+
+
+def evaluate_herd_mood(herd: Herd) -> str:
+    """Return a simple mood label for the given herd."""
+    members = list(herd.members.all())
+    if not members:
+        return "meh"
+
+    now = timezone.now()
+    start_date = now - timedelta(days=3)
+
+    total_shames = 0
+    total_lockouts = 0
+    mood_score = 0
+
+    for member in members:
+        total_shames += ShamePost.objects.filter(
+            user=member, date__gte=start_date.date()
+        ).count()
+        total_lockouts += DailyLockout.objects.filter(
+            user=member, date__gte=start_date.date(), is_unlocked=True
+        ).count()
+        profile = Profile.objects.filter(user=member).first()
+        if profile:
+            mood = profile.current_mood
+            if mood in POSITIVE_MOODS:
+                mood_score += 1
+            elif mood in NEGATIVE_MOODS:
+                mood_score -= 1
+
+    herd_size = len(members)
+    days_span = 3 * herd_size
+    lockout_rate = total_lockouts / days_span if days_span else 0
+    shame_rate = total_shames / days_span if days_span else 0
+    avg_mood = mood_score / herd_size
+
+    if lockout_rate > 0.6 and avg_mood > 0.2 and shame_rate < 0.3:
+        return "vibing"
+    if lockout_rate < 0.3 or avg_mood < -0.2 or shame_rate > 0.5:
+        return "struggling"
+    return "meh"

--- a/backend/core/views.py
+++ b/backend/core/views.py
@@ -17,6 +17,7 @@ from .utils.voice_helpers import (
 from .utils.tts_helpers import text_to_speech
 from .utils.mood_engine import evaluate_user_mood
 from .utils.mood_avatar import get_mood_avatar
+from .utils.herdmood_engine import evaluate_herd_mood
 import uuid
 
 
@@ -270,3 +271,20 @@ def get_mood_avatar_view(request):
     mood = request.user.profile.current_mood
     avatar = get_mood_avatar(mood)
     return Response({"mood": mood, "avatar": avatar})
+
+
+@api_view(["GET"])
+@permission_classes([IsAuthenticated])
+def herd_mood_view(request):
+    """Return the overall mood for the user's herd."""
+    herd = request.user.herds.first()
+    if not herd:
+        return Response({"message": "User is not in a herd."})
+
+    mood = evaluate_herd_mood(herd)
+
+    return Response({
+        "herd": herd.name,
+        "herd_size": herd.members.count(),
+        "herd_mood": mood,
+    })


### PR DESCRIPTION
## Summary
- evaluate herd mood across members in new helper `herdmood_engine.py`
- expose a `herd_mood_view` endpoint for the current user
- register `herd-mood/` route

## Testing
- `pip install -r backend/requirements.txt`
- `pip install python-dotenv`
- `python backend/manage.py test`

------
https://chatgpt.com/codex/tasks/task_e_68509e81e83083239b33aedeb30986bd