### PR TITLE
Add badge sharing support

### DIFF
--- a/backend/core/admin.py
+++ b/backend/core/admin.py
@@ -8,6 +8,7 @@ from .models import (
     VoiceJournal,
     Herd,
     Badge,
+    BadgeShoutout,
 )
 
 
@@ -50,3 +51,8 @@ class HerdAdmin(admin.ModelAdmin):
 @admin.register(Badge)
 class BadgeAdmin(admin.ModelAdmin):
     list_display = ("code", "name", "is_active")
+
+
+@admin.register(BadgeShoutout)
+class BadgeShoutoutAdmin(admin.ModelAdmin):
+    list_display = ("user", "badge", "herd", "created_at")

--- a/backend/core/migrations/0007_badgeshoutout.py
+++ b/backend/core/migrations/0007_badgeshoutout.py
@@ -1,0 +1,22 @@
+from django.db import migrations, models
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('core', '0006_badge_profile_badges'),
+    ]
+
+    operations = [
+        migrations.CreateModel(
+            name='BadgeShoutout',
+            fields=[
+                ('id', models.BigAutoField(auto_created=True, primary_key=True, serialize=False, verbose_name='ID')),
+                ('message', models.TextField()),
+                ('created_at', models.DateTimeField(auto_now_add=True)),
+                ('badge', models.ForeignKey(on_delete=models.deletion.CASCADE, to='core.badge')),
+                ('herd', models.ForeignKey(blank=True, null=True, on_delete=models.deletion.CASCADE, to='core.herd')),
+                ('user', models.ForeignKey(on_delete=models.deletion.CASCADE, to='auth.user')),
+            ],
+            options={'ordering': ['-created_at']},
+        ),
+    ]

--- a/backend/core/models.py
+++ b/backend/core/models.py
@@ -110,3 +110,19 @@ class Herd(models.Model):
 
     def __str__(self) -> str:  # pragma: no cover - simple representation
         return self.name
+
+
+class BadgeShoutout(models.Model):
+    """Record a badge shoutout that can be shared with the user's herd."""
+
+    user = models.ForeignKey(User, on_delete=models.CASCADE)
+    badge = models.ForeignKey(Badge, on_delete=models.CASCADE)
+    herd = models.ForeignKey(Herd, on_delete=models.CASCADE, null=True, blank=True)
+    message = models.TextField()
+    created_at = models.DateTimeField(auto_now_add=True)
+
+    class Meta:
+        ordering = ["-created_at"]
+
+    def __str__(self) -> str:  # pragma: no cover - simple representation
+        return f"{self.user.username} - {self.badge.code}"

--- a/backend/core/serializers.py
+++ b/backend/core/serializers.py
@@ -8,6 +8,7 @@ from .models import (
     VoiceJournal,
     Herd,
     Badge,
+    BadgeShoutout,
 )
 
 
@@ -72,4 +73,10 @@ class HerdSerializer(serializers.ModelSerializer):
 
     class Meta:
         model = Herd
+        fields = "__all__"
+
+
+class BadgeShoutoutSerializer(serializers.ModelSerializer):
+    class Meta:
+        model = BadgeShoutout
         fields = "__all__"

--- a/backend/core/urls.py
+++ b/backend/core/urls.py
@@ -18,6 +18,7 @@ from .views import (
 
     herd_mood_view,
     check_badges,
+    share_badge,
 
 )
 
@@ -41,5 +42,6 @@ urlpatterns = router.urls + [
 
     path("herd-mood/", herd_mood_view),
     path("check-badges/", check_badges),
+    path("share-badge/", share_badge),
 
 ]


### PR DESCRIPTION
## Summary
- add `BadgeShoutout` model for sharing earned badges
- create serializer and admin configuration
- expose `/share-badge/` API endpoint
- refine `/check-badges/` response format
- include migration for new model

## Testing
- `python -m py_compile backend/core/models.py backend/core/views.py backend/core/serializers.py backend/core/admin.py backend/core/migrations/0007_badgeshoutout.py`


------
https://chatgpt.com/codex/tasks/task_e_6850a68a5c808323a8c2fe7471e54ffe