### PR TITLE
Add Today Dashboard API

### DIFF
--- a/backend/core/urls.py
+++ b/backend/core/urls.py
@@ -24,6 +24,7 @@ from .views import (
     generate_workout_plan,
     generate_meal_plan_view,
     generate_donkey_challenge,
+    get_today_dashboard,
 
 )
 
@@ -44,6 +45,7 @@ urlpatterns = router.urls + [
     path("dashboard/", dashboard_feed),
     path("update-mood/", update_mood),
     path("mood-avatar/", get_mood_avatar_view),
+    path("dashboard-today/", get_today_dashboard),
 
     path("herd-mood/", herd_mood_view),
     path("check-badges/", check_badges),


### PR DESCRIPTION
## Summary
- create `get_today_dashboard` API for mood, challenge, plans, and recap
- expose API at `/api/core/dashboard-today/`
- test dashboard endpoint returns full data

## Testing
- `pip install -r requirements.txt`
- `pip install python-dotenv`
- `export OPENAI_API_KEY=dummykey`
- `python manage.py test`

------
https://chatgpt.com/codex/tasks/task_e_6850dd9ec5c8832382547e3528c81a2b