### PR TITLE
Add Flutter TodayPage dashboard

### DIFF
--- a/frontend/momentum_flutter/lib/main.dart
+++ b/frontend/momentum_flutter/lib/main.dart
@@ -1,5 +1,7 @@
 import 'package:flutter/material.dart';
 
+import 'pages/today_page.dart';
+
 void main() {
   runApp(const MyApp());
 }
@@ -7,116 +9,12 @@ void main() {
 class MyApp extends StatelessWidget {
   const MyApp({super.key});
 
-  // This widget is the root of your application.
   @override
   Widget build(BuildContext context) {
     return MaterialApp(
-      title: 'Flutter Demo',
-      theme: ThemeData(
-        // This is the theme of your application.
-        //
-        // TRY THIS: Try running your application with "flutter run". You'll see
-        // the application has a purple toolbar. Then, without quitting the app,
-        // try changing the seedColor in the colorScheme below to Colors.green
-        // and then invoke "hot reload" (save your changes or press the "hot
-        // reload" button in a Flutter-supported IDE, or press "r" if you used
-        // the command line to start the app).
-        //
-        // Notice that the counter didn't reset back to zero; the application
-        // state is not lost during the reload. To reset the state, use hot
-        // restart instead.
-        //
-        // This works for code too, not just values: Most code changes can be
-        // tested with just a hot reload.
-        colorScheme: ColorScheme.fromSeed(seedColor: Colors.deepPurple),
-      ),
-      home: const MyHomePage(title: 'Flutter Demo Home Page'),
-    );
-  }
-}
-
-class MyHomePage extends StatefulWidget {
-  const MyHomePage({super.key, required this.title});
-
-  // This widget is the home page of your application. It is stateful, meaning
-  // that it has a State object (defined below) that contains fields that affect
-  // how it looks.
-
-  // This class is the configuration for the state. It holds the values (in this
-  // case the title) provided by the parent (in this case the App widget) and
-  // used by the build method of the State. Fields in a Widget subclass are
-  // always marked "final".
-
-  final String title;
-
-  @override
-  State<MyHomePage> createState() => _MyHomePageState();
-}
-
-class _MyHomePageState extends State<MyHomePage> {
-  int _counter = 0;
-
-  void _incrementCounter() {
-    setState(() {
-      // This call to setState tells the Flutter framework that something has
-      // changed in this State, which causes it to rerun the build method below
-      // so that the display can reflect the updated values. If we changed
-      // _counter without calling setState(), then the build method would not be
-      // called again, and so nothing would appear to happen.
-      _counter++;
-    });
-  }
-
-  @override
-  Widget build(BuildContext context) {
-    // This method is rerun every time setState is called, for instance as done
-    // by the _incrementCounter method above.
-    //
-    // The Flutter framework has been optimized to make rerunning build methods
-    // fast, so that you can just rebuild anything that needs updating rather
-    // than having to individually change instances of widgets.
-    return Scaffold(
-      appBar: AppBar(
-        // TRY THIS: Try changing the color here to a specific color (to
-        // Colors.amber, perhaps?) and trigger a hot reload to see the AppBar
-        // change color while the other colors stay the same.
-        backgroundColor: Theme.of(context).colorScheme.inversePrimary,
-        // Here we take the value from the MyHomePage object that was created by
-        // the App.build method, and use it to set our appbar title.
-        title: Text(widget.title),
-      ),
-      body: Center(
-        // Center is a layout widget. It takes a single child and positions it
-        // in the middle of the parent.
-        child: Column(
-          // Column is also a layout widget. It takes a list of children and
-          // arranges them vertically. By default, it sizes itself to fit its
-          // children horizontally, and tries to be as tall as its parent.
-          //
-          // Column has various properties to control how it sizes itself and
-          // how it positions its children. Here we use mainAxisAlignment to
-          // center the children vertically; the main axis here is the vertical
-          // axis because Columns are vertical (the cross axis would be
-          // horizontal).
-          //
-          // TRY THIS: Invoke "debug painting" (choose the "Toggle Debug Paint"
-          // action in the IDE, or press "p" in the console), to see the
-          // wireframe for each widget.
-          mainAxisAlignment: MainAxisAlignment.center,
-          children: <Widget>[
-            const Text('You have pushed the button this many times:'),
-            Text(
-              '$_counter',
-              style: Theme.of(context).textTheme.headlineMedium,
-            ),
-          ],
-        ),
-      ),
-      floatingActionButton: FloatingActionButton(
-        onPressed: _incrementCounter,
-        tooltip: 'Increment',
-        child: const Icon(Icons.add),
-      ), // This trailing comma makes auto-formatting nicer for build methods.
+      title: 'MoveYourAzz',
+      theme: ThemeData.dark(),
+      home: const TodayPage(),
     );
   }
 }

--- a/frontend/momentum_flutter/lib/models/today_dashboard.dart
+++ b/frontend/momentum_flutter/lib/models/today_dashboard.dart
@@ -1,0 +1,44 @@
+import 'package:flutter/foundation.dart';
+
+class Challenge {
+  final String text;
+  final DateTime expiresAt;
+
+  Challenge({required this.text, required this.expiresAt});
+
+  factory Challenge.fromJson(Map<String, dynamic> json) {
+    return Challenge(
+      text: json['text'] as String,
+      expiresAt: DateTime.parse(json['expires_at'] as String),
+    );
+  }
+}
+
+class TodayDashboard {
+  final String mood;
+  final String moodAvatar;
+  final Challenge? challenge;
+  final List<String>? workoutPlan;
+  final Map<String, dynamic>? mealPlan;
+  final String recap;
+
+  TodayDashboard({
+    required this.mood,
+    required this.moodAvatar,
+    required this.challenge,
+    required this.workoutPlan,
+    required this.mealPlan,
+    required this.recap,
+  });
+
+  factory TodayDashboard.fromJson(Map<String, dynamic> json) {
+    return TodayDashboard(
+      mood: json['mood'] as String,
+      moodAvatar: json['mood_avatar'] as String? ?? '',
+      challenge: json['challenge'] != null ? Challenge.fromJson(json['challenge'] as Map<String, dynamic>) : null,
+      workoutPlan: (json['workout_plan'] as List?)?.map((e) => e.toString()).toList(),
+      mealPlan: json['meal_plan'] as Map<String, dynamic>?,
+      recap: json['azz_recap'] as String? ?? '',
+    );
+  }
+}

--- a/frontend/momentum_flutter/lib/pages/today_page.dart
+++ b/frontend/momentum_flutter/lib/pages/today_page.dart
@@ -1,0 +1,187 @@
+import 'package:flutter/material.dart';
+import 'package:intl/intl.dart';
+
+import '../models/today_dashboard.dart';
+import '../services/api_service.dart';
+
+class TodayPage extends StatefulWidget {
+  const TodayPage({super.key});
+
+  @override
+  State<TodayPage> createState() => _TodayPageState();
+}
+
+class _TodayPageState extends State<TodayPage> {
+  late Future<TodayDashboard> _future;
+
+  @override
+  void initState() {
+    super.initState();
+    _future = ApiService.fetchTodayDashboard();
+  }
+
+  Future<void> _refresh() async {
+    setState(() {
+      _future = ApiService.fetchTodayDashboard();
+    });
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('MoveYourAzz 🫏'),
+      ),
+      body: RefreshIndicator(
+        onRefresh: _refresh,
+        child: FutureBuilder<TodayDashboard>(
+          future: _future,
+          builder: (context, snapshot) {
+            if (snapshot.connectionState == ConnectionState.waiting) {
+              return const Center(child: CircularProgressIndicator());
+            } else if (snapshot.hasError) {
+              return Center(child: Text('Error: ${snapshot.error}'));
+            }
+
+            final dashboard = snapshot.data!;
+            return ListView(
+              padding: const EdgeInsets.all(16),
+              children: [
+                _buildMood(dashboard),
+                _buildChallenge(dashboard.challenge),
+                _buildWorkout(dashboard.workoutPlan),
+                _buildMeal(dashboard.mealPlan),
+                _buildRecap(dashboard.recap),
+              ],
+            );
+          },
+        ),
+      ),
+    );
+  }
+
+  Widget _buildMood(TodayDashboard dashboard) {
+    return Card(
+      child: ListTile(
+        leading: Text(
+          dashboard.moodAvatar.isNotEmpty ? dashboard.moodAvatar : '😶',
+          style: const TextStyle(fontSize: 32),
+        ),
+        title: Text('Current Mood: ${dashboard.mood}'),
+      ),
+    );
+  }
+
+  Widget _buildChallenge(Challenge? challenge) {
+    if (challenge == null) {
+      return const SizedBox.shrink();
+    }
+    return Card(
+      child: Padding(
+        padding: const EdgeInsets.all(16),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Text(
+              challenge.text,
+              style: Theme.of(context).textTheme.titleMedium,
+            ),
+            const SizedBox(height: 8),
+            Text(
+              'Deadline: ${DateFormat.yMMMMd().add_jm().format(challenge.expiresAt)}',
+              style: Theme.of(context).textTheme.bodySmall,
+            ),
+            const SizedBox(height: 8),
+            Row(
+              children: [
+                ElevatedButton(
+                  onPressed: () {},
+                  child: const Text('Mark Complete'),
+                ),
+                const SizedBox(width: 8),
+                OutlinedButton(
+                  onPressed: () {},
+                  child: const Text('Share to Herd'),
+                ),
+              ],
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+
+  Widget _buildWorkout(List<String>? plan) {
+    return Card(
+      child: Padding(
+        padding: const EdgeInsets.all(16),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Text(
+              'Workout Plan',
+              style: Theme.of(context).textTheme.titleMedium,
+            ),
+            const SizedBox(height: 8),
+            if (plan == null || plan.isEmpty)
+              const Text('No plan set today')
+            else
+              Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: plan.map((e) => Text(e)).toList(),
+              ),
+          ],
+        ),
+      ),
+    );
+  }
+
+  Widget _buildMeal(Map<String, dynamic>? mealPlan) {
+    return Card(
+      child: Padding(
+        padding: const EdgeInsets.all(16),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Text(
+              'Meal Plan',
+              style: Theme.of(context).textTheme.titleMedium,
+            ),
+            const SizedBox(height: 8),
+            if (mealPlan == null || mealPlan.isEmpty)
+              const Text('No meal plan today')
+            else
+              Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: mealPlan.entries
+                    .map((e) => Text('🍽️ ${e.key}: ${e.value}'))
+                    .toList(),
+              ),
+          ],
+        ),
+      ),
+    );
+  }
+
+  Widget _buildRecap(String recap) {
+    return Card(
+      child: Padding(
+        padding: const EdgeInsets.all(16),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Text(
+              'Donkey Recap',
+              style: Theme.of(context).textTheme.titleMedium,
+            ),
+            const SizedBox(height: 8),
+            Text(
+              recap,
+              style: const TextStyle(fontStyle: FontStyle.italic),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/frontend/momentum_flutter/lib/services/api_service.dart
+++ b/frontend/momentum_flutter/lib/services/api_service.dart
@@ -1,0 +1,29 @@
+import 'dart:convert';
+import 'package:http/http.dart' as http;
+import 'package:shared_preferences/shared_preferences.dart';
+
+import '../models/today_dashboard.dart';
+
+class ApiService {
+  static const String baseUrl = 'http://localhost:8000';
+
+  static Future<TodayDashboard> fetchTodayDashboard() async {
+    final prefs = await SharedPreferences.getInstance();
+    final token = prefs.getString('auth_token') ?? '';
+
+    final response = await http.get(
+      Uri.parse('$baseUrl/api/core/dashboard-today/'),
+      headers: {
+        'Content-Type': 'application/json',
+        if (token.isNotEmpty) 'Authorization': 'Bearer $token',
+      },
+    );
+
+    if (response.statusCode != 200) {
+      throw Exception('Failed to load dashboard');
+    }
+
+    final data = json.decode(response.body) as Map<String, dynamic>;
+    return TodayDashboard.fromJson(data);
+  }
+}

--- a/frontend/momentum_flutter/pubspec.yaml
+++ b/frontend/momentum_flutter/pubspec.yaml
@@ -35,6 +35,7 @@ dependencies:
   provider: ^6.0.0
   shared_preferences: ^2.0.15
   url_launcher: ^6.1.7
+  intl: ^0.18.0
 
   # The following adds the Cupertino Icons font to your application.
   # Use with the CupertinoIcons class for iOS style icons.

--- a/frontend/momentum_flutter/test/widget_test.dart
+++ b/frontend/momentum_flutter/test/widget_test.dart
@@ -1,30 +1,12 @@
-// This is a basic Flutter widget test.
-//
-// To perform an interaction with a widget in your test, use the WidgetTester
-// utility in the flutter_test package. For example, you can send tap and scroll
-// gestures. You can also use WidgetTester to find child widgets in the widget
-// tree, read text, and verify that the values of widget properties are correct.
-
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
-
 import 'package:momentum_flutter/main.dart';
 
 void main() {
-  testWidgets('Counter increments smoke test', (WidgetTester tester) async {
-    // Build our app and trigger a frame.
+  testWidgets('TodayPage loads', (WidgetTester tester) async {
     await tester.pumpWidget(const MyApp());
 
-    // Verify that our counter starts at 0.
-    expect(find.text('0'), findsOneWidget);
-    expect(find.text('1'), findsNothing);
-
-    // Tap the '+' icon and trigger a frame.
-    await tester.tap(find.byIcon(Icons.add));
-    await tester.pump();
-
-    // Verify that our counter has incremented.
-    expect(find.text('0'), findsNothing);
-    expect(find.text('1'), findsOneWidget);
+    expect(find.text('MoveYourAzz 🫏'), findsOneWidget);
+    expect(find.byType(ListView), findsOneWidget);
   });
 }


### PR DESCRIPTION
## Summary
- implement `TodayPage` with RefreshIndicator and cards
- fetch `/api/core/dashboard-today/` via new ApiService
- parse data with `TodayDashboard` model
- simplify `main.dart` to show TodayPage with dark theme
- adjust widget test for new home screen
- add `intl` dependency for date formatting

## Testing
- `flutter pub get` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6850e30df4f48323a3e9aaa9428a49ae