### PR TITLE
Add Makefile for unified dev workflow

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,57 @@
+# Root Makefile for MoveYourAzz
+SHELL := /bin/bash
+
+BACKEND_DIR := backend
+FRONTEND_DIR := frontend/momentum_flutter
+ACTIVATE = source .venv/bin/activate || true
+
+.PHONY: run-backend migrate makemigrations test-backend lint-backend \
+    run-frontend test-frontend lint-frontend install-backend install-frontend \
+    azzify reset-db refresh reset-all
+
+# == Backend Commands ==
+run-backend:
+	cd $(BACKEND_DIR) && $(ACTIVATE) && python manage.py runserver
+
+migrate:
+	cd $(BACKEND_DIR) && $(ACTIVATE) && python manage.py migrate
+
+makemigrations:
+	cd $(BACKEND_DIR) && $(ACTIVATE) && python manage.py makemigrations
+
+test-backend:
+	cd $(BACKEND_DIR) && $(ACTIVATE) && python manage.py test
+
+lint-backend:
+	cd $(BACKEND_DIR) && flake8
+
+# == Frontend Commands ==
+run-frontend:
+	cd $(FRONTEND_DIR) && flutter run
+
+test-frontend:
+	cd $(FRONTEND_DIR) && flutter test
+
+lint-frontend:
+	cd $(FRONTEND_DIR) && flutter analyze
+
+# == Setup ==
+install-backend:
+	cd $(BACKEND_DIR) && python3 -m venv .venv && $(ACTIVATE) && pip install -r requirements.txt
+
+install-frontend:
+	cd $(FRONTEND_DIR) && flutter pub get
+
+# == Utilities ==
+azzify:
+	cd $(BACKEND_DIR) && python manage.py azzify_texts
+
+reset-db:
+	cd $(BACKEND_DIR) && $(ACTIVATE) && python manage.py flush
+
+refresh:
+	$(MAKE) migrate && $(MAKE) run-backend
+
+reset-all:
+	$(MAKE) reset-db && $(MAKE) run-frontend
+


### PR DESCRIPTION
## Summary
- add a root Makefile with helpers for backend and frontend

## Testing
- `make test-backend` *(fails: ModuleNotFoundError: No module named 'django')*
- `make test-frontend` *(fails: flutter: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6850e8c78ff4832388eb2eef57f0383b