### PR TITLE
Add meme share preview screen

### DIFF
--- a/frontend/momentum_flutter/lib/models/meme.dart
+++ b/frontend/momentum_flutter/lib/models/meme.dart
@@ -1,0 +1,15 @@
+class Meme {
+  final String imageUrl;
+  final String caption;
+  final String tone;
+
+  Meme({required this.imageUrl, required this.caption, required this.tone});
+
+  factory Meme.fromJson(Map<String, dynamic> json) {
+    return Meme(
+      imageUrl: json['image_url'] as String,
+      caption: json['caption'] as String,
+      tone: json['tone'] as String? ?? 'funny',
+    );
+  }
+}

--- a/frontend/momentum_flutter/lib/pages/meme_share_page.dart
+++ b/frontend/momentum_flutter/lib/pages/meme_share_page.dart
@@ -1,0 +1,58 @@
+import 'package:flutter/material.dart';
+import 'package:share_plus/share_plus.dart';
+import 'package:gallery_saver/gallery_saver.dart';
+
+import '../models/meme.dart';
+
+class MemeSharePage extends StatelessWidget {
+  final Meme meme;
+
+  const MemeSharePage({required this.meme, Key? key}) : super(key: key);
+
+  Future<void> saveMemeToDevice(Meme meme) async {
+    await GallerySaver.saveImage(meme.imageUrl);
+  }
+
+  void shareMeme(Meme meme) {
+    Share.share('${meme.caption}\n${meme.imageUrl}');
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: const Text('Meme Preview 🫏')),
+      body: Column(
+        children: [
+          Expanded(
+            child: Image.network(
+              meme.imageUrl,
+              fit: BoxFit.contain,
+              errorBuilder: (context, error, stackTrace) {
+                return const Center(
+                  child: Text('Failed to load meme image 🫏'),
+                );
+              },
+            ),
+          ),
+          Padding(
+            padding: const EdgeInsets.all(12),
+            child: Text(
+              meme.caption,
+              style: const TextStyle(fontSize: 18, fontStyle: FontStyle.italic),
+              textAlign: TextAlign.center,
+            ),
+          ),
+          ElevatedButton(
+            onPressed: () => saveMemeToDevice(meme),
+            child: const Text('💾 Save to Device'),
+          ),
+          ElevatedButton(
+            onPressed: () => shareMeme(meme),
+            child: const Text('📤 Share Meme'),
+          ),
+          const SizedBox(height: 20),
+        ],
+      ),
+    );
+  }
+}

--- a/frontend/momentum_flutter/lib/services/api_service.dart
+++ b/frontend/momentum_flutter/lib/services/api_service.dart
@@ -4,6 +4,7 @@ import 'package:shared_preferences/shared_preferences.dart';
 
 import '../models/today_dashboard.dart';
 import '../models/badge.dart';
+import '../models/meme.dart';
 
 class ApiService {
   static const String baseUrl = 'http://localhost:8000';
@@ -46,5 +47,26 @@ class ApiService {
 
     final List data = json.decode(response.body) as List;
     return data.map((e) => Badge.fromJson(e as Map<String, dynamic>)).toList();
+  }
+
+  static Future<Meme> generateMeme({String tone = 'funny'}) async {
+    final prefs = await SharedPreferences.getInstance();
+    final token = prefs.getString('auth_token') ?? '';
+
+    final response = await http.post(
+      Uri.parse('$baseUrl/api/content/generate-meme/'),
+      headers: {
+        'Content-Type': 'application/json',
+        if (token.isNotEmpty) 'Authorization': 'Bearer $token',
+      },
+      body: json.encode({'tone': tone}),
+    );
+
+    if (response.statusCode != 200) {
+      throw Exception('Failed to generate meme');
+    }
+
+    final data = json.decode(response.body) as Map<String, dynamic>;
+    return Meme.fromJson(data);
   }
 }

--- a/frontend/momentum_flutter/pubspec.yaml
+++ b/frontend/momentum_flutter/pubspec.yaml
@@ -36,6 +36,8 @@ dependencies:
   shared_preferences: ^2.0.15
   url_launcher: ^6.1.7
   intl: ^0.18.0
+  share_plus: ^7.2.1
+  gallery_saver: ^2.3.2
 
   # The following adds the Cupertino Icons font to your application.
   # Use with the CupertinoIcons class for iOS style icons.


### PR DESCRIPTION
## Summary
- add Meme model for generated donkey memes
- add MemeSharePage UI for previewing and sharing
- enable generating memes via ApiService
- add `share_plus` and `gallery_saver` deps for saving/sharing

## Testing
- `flutter analyze` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6850eaa0d87083239b9431a6739ae3b8