### PR TITLE
Add meme share preview screen

### DIFF
--- a/frontend/momentum_flutter/lib/models/meme.dart
+++ b/frontend/momentum_flutter/lib/models/meme.dart
@@ -1,0 +1,16 @@
+class Meme {
+  final String imageUrl;
+  final String caption;
+  final String tone;
+
+  Meme({required this.imageUrl, required this.caption, required this.tone});
+
+  factory Meme.fromJson(Map<String, dynamic> json) {
+    return Meme(
+      imageUrl: json['image_url'] as String,
+      caption: json['caption'] as String,
+      tone: json['tone'] as String? ?? 'funny',
+    );
+  }
+}
+

--- a/frontend/momentum_flutter/lib/pages/meme_share_page.dart
+++ b/frontend/momentum_flutter/lib/pages/meme_share_page.dart
@@ -1,0 +1,73 @@
+import 'dart:io';
+
+import 'package:flutter/material.dart';
+import 'package:http/http.dart' as http;
+import 'package:path_provider/path_provider.dart';
+import 'package:share_plus/share_plus.dart';
+import 'package:gallery_saver/gallery_saver.dart';
+
+import '../models/meme.dart';
+
+class MemeSharePage extends StatelessWidget {
+  final Meme meme;
+
+  const MemeSharePage({super.key, required this.meme});
+
+  Future<void> saveMemeToDevice(Meme meme) async {
+    try {
+      final response = await http.get(Uri.parse(meme.imageUrl));
+      if (response.statusCode == 200) {
+        final directory = await getTemporaryDirectory();
+        final path =
+            '${directory.path}/meme_${DateTime.now().millisecondsSinceEpoch}.png';
+        final file = File(path);
+        await file.writeAsBytes(response.bodyBytes);
+        await GallerySaver.saveImage(file.path);
+      }
+    } catch (e) {
+      debugPrint('Failed to save meme: $e');
+    }
+  }
+
+  void shareMeme(Meme meme) {
+    Share.share('${meme.caption}\n${meme.imageUrl}');
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: const Text('Meme Preview 🫏')),
+      body: Column(
+        children: [
+          Expanded(
+            child: Image.network(
+              meme.imageUrl,
+              fit: BoxFit.contain,
+              errorBuilder: (context, error, stackTrace) => const Center(
+                child: Text('Failed to load image'),
+              ),
+            ),
+          ),
+          Padding(
+            padding: const EdgeInsets.all(12),
+            child: Text(
+              meme.caption,
+              style:
+                  const TextStyle(fontSize: 18, fontStyle: FontStyle.italic),
+              textAlign: TextAlign.center,
+            ),
+          ),
+          ElevatedButton(
+            onPressed: () => saveMemeToDevice(meme),
+            child: const Text('💾 Save to Device'),
+          ),
+          ElevatedButton(
+            onPressed: () => shareMeme(meme),
+            child: const Text('📤 Share Meme'),
+          ),
+        ],
+      ),
+    );
+  }
+}
+

--- a/frontend/momentum_flutter/lib/pages/today_page.dart
+++ b/frontend/momentum_flutter/lib/pages/today_page.dart
@@ -4,6 +4,7 @@ import 'package:intl/intl.dart';
 import '../models/today_dashboard.dart';
 import '../services/api_service.dart';
 import 'badge_grid_page.dart';
+import 'meme_share_page.dart';
 
 class TodayPage extends StatefulWidget {
   const TodayPage({super.key});
@@ -39,6 +40,18 @@ class _TodayPageState extends State<TodayPage> {
               Navigator.of(context).push(
                 MaterialPageRoute(
                   builder: (_) => const BadgeGridPage(),
+                ),
+              );
+            },
+          ),
+          IconButton(
+            icon: const Icon(Icons.image),
+            onPressed: () async {
+              final meme = await ApiService.generateMeme();
+              if (!mounted) return;
+              Navigator.of(context).push(
+                MaterialPageRoute(
+                  builder: (_) => MemeSharePage(meme: meme),
                 ),
               );
             },

--- a/frontend/momentum_flutter/lib/services/api_service.dart
+++ b/frontend/momentum_flutter/lib/services/api_service.dart
@@ -4,6 +4,7 @@ import 'package:shared_preferences/shared_preferences.dart';
 
 import '../models/today_dashboard.dart';
 import '../models/badge.dart';
+import '../models/meme.dart';
 
 class ApiService {
   static const String baseUrl = 'http://localhost:8000';
@@ -46,5 +47,26 @@ class ApiService {
 
     final List data = json.decode(response.body) as List;
     return data.map((e) => Badge.fromJson(e as Map<String, dynamic>)).toList();
+  }
+
+  static Future<Meme> generateMeme({String tone = 'funny'}) async {
+    final prefs = await SharedPreferences.getInstance();
+    final token = prefs.getString('auth_token') ?? '';
+
+    final response = await http.post(
+      Uri.parse('$baseUrl/api/content/generate-meme/'),
+      headers: {
+        'Content-Type': 'application/json',
+        if (token.isNotEmpty) 'Authorization': 'Bearer $token',
+      },
+      body: json.encode({'tone': tone}),
+    );
+
+    if (response.statusCode != 200) {
+      throw Exception('Failed to generate meme');
+    }
+
+    final data = json.decode(response.body) as Map<String, dynamic>;
+    return Meme.fromJson(data);
   }
 }

--- a/frontend/momentum_flutter/pubspec.yaml
+++ b/frontend/momentum_flutter/pubspec.yaml
@@ -36,6 +36,9 @@ dependencies:
   shared_preferences: ^2.0.15
   url_launcher: ^6.1.7
   intl: ^0.18.0
+  share_plus: ^7.2.1
+  path_provider: ^2.1.2
+  gallery_saver: ^2.3.2
 
   # The following adds the Cupertino Icons font to your application.
   # Use with the CupertinoIcons class for iOS style icons.

--- a/frontend/momentum_flutter/test/widget_test.dart
+++ b/frontend/momentum_flutter/test/widget_test.dart
@@ -1,6 +1,8 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:momentum_flutter/main.dart';
+import 'package:momentum_flutter/models/meme.dart';
+import 'package:momentum_flutter/pages/meme_share_page.dart';
 
 void main() {
   testWidgets('TodayPage loads', (WidgetTester tester) async {
@@ -8,5 +10,22 @@ void main() {
 
     expect(find.text('MoveYourAzz 🫏'), findsOneWidget);
     expect(find.byType(ListView), findsOneWidget);
+  });
+
+  testWidgets('MemeSharePage shows caption and image', (tester) async {
+    final meme = Meme(
+      imageUrl: 'https://example.com/meme.png',
+      caption: 'funny caption',
+      tone: 'funny',
+    );
+
+    await tester.pumpWidget(
+      MaterialApp(
+        home: MemeSharePage(meme: meme),
+      ),
+    );
+
+    expect(find.text('funny caption'), findsOneWidget);
+    expect(find.byType(Image), findsOneWidget);
   });
 }


### PR DESCRIPTION
## Summary
- model class `Meme` to hold generated meme data
- preview/share UI in `MemeSharePage`
- fetch meme from backend and launch share page from Today screen
- add share & save helpers using `share_plus`
- update dependencies
- expand widget tests

## Testing
- `pytest -q`
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6850eaa0d87083239b9431a6739ae3b8