### PR TITLE
Add user auth system

### DIFF
--- a/backend/core/tests.py
+++ b/backend/core/tests.py
@@ -1,5 +1,28 @@
 from rest_framework.test import APITestCase
 from django.contrib.auth.models import User
+from rest_framework.authtoken.models import Token
+
+
+class AuthAPITest(APITestCase):
+    def test_register_and_login(self):
+        # Register new user
+        response = self.client.post(
+            "/api/core/register/",
+            {"username": "newbie", "password": "pass"},
+            format="json",
+        )
+        self.assertEqual(response.status_code, 201)
+
+        # Login and get token
+        response = self.client.post(
+            "/api/core/login/",
+            {"username": "newbie", "password": "pass"},
+            format="json",
+        )
+        self.assertEqual(response.status_code, 200)
+        self.assertIn("token", response.data)
+        token = response.data["token"]
+        self.assertTrue(Token.objects.filter(key=token).exists())
 
 class MovementGoalAPITest(APITestCase):
     def setUp(self):

--- a/backend/core/urls.py
+++ b/backend/core/urls.py
@@ -26,7 +26,8 @@ from .views import (
     generate_meal_plan_view,
     generate_donkey_challenge,
     get_today_dashboard,
-
+    register_user,
+    CustomAuthToken,
 )
 
 router = DefaultRouter()
@@ -37,6 +38,8 @@ router.register(r"shame-posts", ShamePostViewSet)
 router.register(r"paddle-logs", PaddleLogViewSet)
 
 urlpatterns = router.urls + [
+    path("register/", register_user),
+    path("login/", CustomAuthToken.as_view()),
     path("trigger-shame/", trigger_shame_view),
     path("upload-voice/", upload_voice_journal),
     path("create-herd/", create_herd),

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -19,4 +19,5 @@ sqlparse==0.5.3
 tqdm==4.67.1
 typing-inspection==0.4.1
 typing_extensions==4.14.0
+python-dotenv==1.0.1
 requests==2.32.3

--- a/backend/server/settings.py
+++ b/backend/server/settings.py
@@ -39,6 +39,7 @@ INSTALLED_APPS = [
     "django.contrib.messages",
     "django.contrib.staticfiles",
     "rest_framework",
+    "rest_framework.authtoken",
 
     "core",
     "prompts",
@@ -129,3 +130,11 @@ MEDIA_ROOT = os.path.join(BASE_DIR, "media")
 # https://docs.djangoproject.com/en/5.2/ref/settings/#default-auto-field
 
 DEFAULT_AUTO_FIELD = "django.db.models.BigAutoField"
+
+# Django REST Framework settings
+REST_FRAMEWORK = {
+    "DEFAULT_AUTHENTICATION_CLASSES": [
+        "rest_framework.authentication.TokenAuthentication",
+        "rest_framework.authentication.SessionAuthentication",
+    ]
+}

--- a/frontend/momentum_flutter/pubspec.yaml
+++ b/frontend/momentum_flutter/pubspec.yaml
@@ -34,6 +34,7 @@ dependencies:
   http: ^0.13.6
   provider: ^6.0.0
   shared_preferences: ^2.0.15
+  flutter_secure_storage: ^9.0.0
   url_launcher: ^6.1.7
   intl: ^0.18.0
   share_plus: ^7.2.1


### PR DESCRIPTION
## Summary
- enable `rest_framework.authtoken`
- add registration & login views
- provide API routes for auth endpoints
- store tokens with secure storage in the Flutter app
- add tests for register/login

## Testing
- `make migrate`
- `make test-backend`


------
https://chatgpt.com/codex/tasks/task_e_6850f01a8a7c83238f0863db3362ab3b