### PR TITLE
Implement Flutter token storage service

### DIFF
--- a/frontend/momentum_flutter/lib/services/api_service.dart
+++ b/frontend/momentum_flutter/lib/services/api_service.dart
@@ -1,6 +1,6 @@
 import 'dart:convert';
 import 'package:http/http.dart' as http;
-import 'package:flutter_secure_storage/flutter_secure_storage.dart';
+import 'token_service.dart';
 
 import '../models/today_dashboard.dart';
 import '../models/badge.dart';
@@ -8,10 +8,9 @@ import '../models/meme.dart';
 
 class ApiService {
   static const String baseUrl = 'http://localhost:8000';
-  static const FlutterSecureStorage _storage = FlutterSecureStorage();
 
   static Future<TodayDashboard> fetchTodayDashboard() async {
-    final token = await _storage.read(key: 'auth_token') ?? '';
+    final token = await TokenService.getToken() ?? '';
 
     final response = await http.get(
       Uri.parse('$baseUrl/api/core/dashboard-today/'),
@@ -30,7 +29,7 @@ class ApiService {
   }
 
   static Future<List<Badge>> fetchBadges() async {
-    final token = await _storage.read(key: 'auth_token') ?? '';
+    final token = await TokenService.getToken() ?? '';
 
     final response = await http.get(
       Uri.parse('$baseUrl/api/core/badges/'),
@@ -49,7 +48,7 @@ class ApiService {
   }
 
   static Future<Meme> generateMeme({String tone = 'funny'}) async {
-    final token = await _storage.read(key: 'auth_token') ?? '';
+    final token = await TokenService.getToken() ?? '';
 
     final response = await http.post(
       Uri.parse('$baseUrl/api/content/generate-meme/'),
@@ -90,7 +89,7 @@ class ApiService {
     }
     final data = json.decode(response.body) as Map<String, dynamic>;
     final token = data['token'] as String;
-    await _storage.write(key: 'auth_token', value: token);
+    await TokenService.saveToken(token);
     return token;
   }
 }

--- a/frontend/momentum_flutter/lib/services/token_service.dart
+++ b/frontend/momentum_flutter/lib/services/token_service.dart
@@ -1,0 +1,23 @@
+import 'package:flutter_secure_storage/flutter_secure_storage.dart';
+
+class TokenService {
+  static final _storage = const FlutterSecureStorage();
+  static const _tokenKey = 'auth_token';
+
+  static Future<void> saveToken(String token) async {
+    await _storage.write(key: _tokenKey, value: token);
+  }
+
+  static Future<String?> getToken() async {
+    return await _storage.read(key: _tokenKey);
+  }
+
+  static Future<void> clearToken() async {
+    await _storage.delete(key: _tokenKey);
+  }
+
+  static Future<bool> isAuthenticated() async {
+    final token = await getToken();
+    return token != null && token.isNotEmpty;
+  }
+}


### PR DESCRIPTION
## Summary
- add `TokenService` for managing auth tokens
- use `TokenService` within API calls

## Testing
- `make test-frontend` *(fails: flutter not installed)*
- `make test-backend` *(fails: OPENAI_API_KEY missing)*

------
https://chatgpt.com/codex/tasks/task_e_6850f50dacac8323a4d9dfada993cc6b