### PR TITLE
Add Flutter auth screens

### DIFF
--- a/frontend/momentum_flutter/lib/main.dart
+++ b/frontend/momentum_flutter/lib/main.dart
@@ -1,7 +1,9 @@
 import 'package:flutter/material.dart';
 
 import 'pages/today_page.dart';
+import 'pages/login_page.dart';
 import 'themes/app_theme.dart';
+import 'services/token_service.dart';
 
 
 void main() {
@@ -13,10 +15,23 @@ class MyApp extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return MaterialApp(
-      title: 'MoveYourAzz',
-      theme: AppTheme.theme,
-      home: const TodayPage(),
+    return FutureBuilder<bool>(
+      future: TokenService.isAuthenticated(),
+      builder: (context, snapshot) {
+        if (snapshot.connectionState == ConnectionState.waiting) {
+          return const MaterialApp(
+            home: Scaffold(
+              body: Center(child: CircularProgressIndicator()),
+            ),
+          );
+        }
+        final loggedIn = snapshot.data == true;
+        return MaterialApp(
+          title: 'MoveYourAzz',
+          theme: AppTheme.theme,
+          home: loggedIn ? const TodayPage() : const LoginPage(),
+        );
+      },
     );
   }
 }

--- a/frontend/momentum_flutter/lib/pages/login_page.dart
+++ b/frontend/momentum_flutter/lib/pages/login_page.dart
@@ -1,0 +1,99 @@
+import 'package:flutter/material.dart';
+
+import '../services/api_service.dart';
+import '../services/token_service.dart';
+import 'register_page.dart';
+import 'today_page.dart';
+
+class LoginPage extends StatefulWidget {
+  const LoginPage({super.key});
+
+  @override
+  State<LoginPage> createState() => _LoginPageState();
+}
+
+class _LoginPageState extends State<LoginPage> {
+  final _usernameController = TextEditingController();
+  final _passwordController = TextEditingController();
+  String? _error;
+  bool _loading = false;
+
+  Future<void> _login() async {
+    setState(() {
+      _error = null;
+      _loading = true;
+    });
+    try {
+      await ApiService.login(
+        _usernameController.text.trim(),
+        _passwordController.text,
+      );
+      if (!mounted) return;
+      Navigator.pushReplacement(
+        context,
+        MaterialPageRoute(builder: (_) => const TodayPage()),
+      );
+    } catch (e) {
+      setState(() => _error = 'Login failed');
+    } finally {
+      if (mounted) {
+        setState(() => _loading = false);
+      }
+    }
+  }
+
+  @override
+  void dispose() {
+    _usernameController.dispose();
+    _passwordController.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: const Text('Login')),
+      body: Padding(
+        padding: const EdgeInsets.all(16),
+        child: Column(
+          mainAxisAlignment: MainAxisAlignment.center,
+          children: [
+            TextField(
+              controller: _usernameController,
+              decoration: const InputDecoration(labelText: 'Username'),
+            ),
+            const SizedBox(height: 12),
+            TextField(
+              controller: _passwordController,
+              decoration: const InputDecoration(labelText: 'Password'),
+              obscureText: true,
+            ),
+            if (_error != null) ...[
+              const SizedBox(height: 12),
+              Text(
+                _error!,
+                style: const TextStyle(color: Colors.red),
+              ),
+            ],
+            const SizedBox(height: 20),
+            ElevatedButton(
+              onPressed: _loading ? null : _login,
+              child: _loading
+                  ? const CircularProgressIndicator()
+                  : const Text('Login'),
+            ),
+            TextButton(
+              onPressed: () {
+                Navigator.push(
+                  context,
+                  MaterialPageRoute(builder: (_) => const RegisterPage()),
+                );
+              },
+              child: const Text('Need an account? Register'),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/frontend/momentum_flutter/lib/pages/register_page.dart
+++ b/frontend/momentum_flutter/lib/pages/register_page.dart
@@ -1,0 +1,102 @@
+import 'package:flutter/material.dart';
+
+import '../services/api_service.dart';
+import 'login_page.dart';
+import 'today_page.dart';
+
+class RegisterPage extends StatefulWidget {
+  const RegisterPage({super.key});
+
+  @override
+  State<RegisterPage> createState() => _RegisterPageState();
+}
+
+class _RegisterPageState extends State<RegisterPage> {
+  final _usernameController = TextEditingController();
+  final _passwordController = TextEditingController();
+  String? _error;
+  bool _loading = false;
+
+  Future<void> _register() async {
+    setState(() {
+      _error = null;
+      _loading = true;
+    });
+    try {
+      await ApiService.register(
+        _usernameController.text.trim(),
+        _passwordController.text,
+      );
+      await ApiService.login(
+        _usernameController.text.trim(),
+        _passwordController.text,
+      );
+      if (!mounted) return;
+      Navigator.pushReplacement(
+        context,
+        MaterialPageRoute(builder: (_) => const TodayPage()),
+      );
+    } catch (e) {
+      setState(() => _error = 'Registration failed');
+    } finally {
+      if (mounted) {
+        setState(() => _loading = false);
+      }
+    }
+  }
+
+  @override
+  void dispose() {
+    _usernameController.dispose();
+    _passwordController.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: const Text('Register')),
+      body: Padding(
+        padding: const EdgeInsets.all(16),
+        child: Column(
+          mainAxisAlignment: MainAxisAlignment.center,
+          children: [
+            TextField(
+              controller: _usernameController,
+              decoration: const InputDecoration(labelText: 'Username'),
+            ),
+            const SizedBox(height: 12),
+            TextField(
+              controller: _passwordController,
+              decoration: const InputDecoration(labelText: 'Password'),
+              obscureText: true,
+            ),
+            if (_error != null) ...[
+              const SizedBox(height: 12),
+              Text(
+                _error!,
+                style: const TextStyle(color: Colors.red),
+              ),
+            ],
+            const SizedBox(height: 20),
+            ElevatedButton(
+              onPressed: _loading ? null : _register,
+              child: _loading
+                  ? const CircularProgressIndicator()
+                  : const Text('Register'),
+            ),
+            TextButton(
+              onPressed: () {
+                Navigator.push(
+                  context,
+                  MaterialPageRoute(builder: (_) => const LoginPage()),
+                );
+              },
+              child: const Text('Have an account? Login'),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/frontend/momentum_flutter/lib/pages/today_page.dart
+++ b/frontend/momentum_flutter/lib/pages/today_page.dart
@@ -4,6 +4,8 @@ import 'package:intl/intl.dart';
 import '../models/today_dashboard.dart';
 import '../services/api_service.dart';
 import 'badge_grid_page.dart';
+import '../services/token_service.dart';
+import 'login_page.dart';
 
 class TodayPage extends StatefulWidget {
   const TodayPage({super.key});
@@ -33,6 +35,17 @@ class _TodayPageState extends State<TodayPage> {
       appBar: AppBar(
         title: const Text('MoveYourAzz 🫏'),
         actions: [
+          IconButton(
+            icon: const Icon(Icons.logout),
+            onPressed: () async {
+              await TokenService.clearToken();
+              if (!mounted) return;
+              Navigator.pushReplacement(
+                context,
+                MaterialPageRoute(builder: (_) => const LoginPage()),
+              );
+            },
+          ),
           IconButton(
             icon: const Icon(Icons.emoji_events),
             onPressed: () {

--- a/frontend/momentum_flutter/test/widget_test.dart
+++ b/frontend/momentum_flutter/test/widget_test.dart
@@ -1,12 +1,22 @@
 import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:momentum_flutter/main.dart';
 
 void main() {
-  testWidgets('TodayPage loads', (WidgetTester tester) async {
-    await tester.pumpWidget(const MyApp());
+  const MethodChannel channel =
+      MethodChannel('plugins.flutter.io/flutter_secure_storage');
+  TestWidgetsFlutterBinding.ensureInitialized();
+  channel.setMockMethodCallHandler((MethodCall methodCall) async {
+    return null;
+  });
 
-    expect(find.text('MoveYourAzz 🫏'), findsOneWidget);
-    expect(find.byType(ListView), findsOneWidget);
+  testWidgets('Shows login screen when not authenticated',
+      (WidgetTester tester) async {
+    await tester.pumpWidget(const MyApp());
+    await tester.pump();
+
+    expect(find.text('Login'), findsOneWidget);
+    expect(find.byType(TextField), findsNWidgets(2));
   });
 }


### PR DESCRIPTION
## Summary
- add login and registration screens
- update main.dart to route users based on authentication
- provide logout button in TodayPage
- adjust widget tests for new login screen

## Testing
- `dart format` *(fails: command not found)*
- `flutter format` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6850f82f84c48323a9901f4ed8ca897e