### PR TITLE
Fix ElevatedButton textStyle inheritance

### DIFF
--- a/frontend/momentum_flutter/lib/themes/app_theme.dart
+++ b/frontend/momentum_flutter/lib/themes/app_theme.dart
@@ -33,7 +33,9 @@ class AppTheme {
         style: ElevatedButton.styleFrom(
           backgroundColor: AppColors.donkeyGold,
           foregroundColor: Colors.black,
-          textStyle: TextStyle(fontWeight: FontWeight.bold, inherit: true),
+          // Ensure consistent interpolation by matching Flutter defaults
+          textStyle:
+              const TextStyle(fontWeight: FontWeight.bold, inherit: false),
         ),
       ),
       inputDecorationTheme: InputDecorationTheme(


### PR DESCRIPTION
## Summary
- adjust ElevatedButton `textStyle` inheritance in `AppTheme` to avoid runtime errors

## Testing
- `make lint-frontend` *(fails: flutter: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6850fd76cd008323af15db96c3934331