### PR TITLE
Fix meal plan display and badge checks

### DIFF
--- a/backend/core/utils/recap_engine.py
+++ b/backend/core/utils/recap_engine.py
@@ -49,7 +49,7 @@ def generate_weekly_recap(user):
     ]
 
     if tone == "legend":
-        lines.append("This donkey salutes you. You’ve earned a badge in badazzery. \U0001f3c6\U0001f9a4")
+        lines.append("This donkey salutes you. You’ve earned a badge in badazzery. 🏆🫏")
     elif tone == "resilient":
         lines.append("You had your off days, but you kept moving. The donkey sees the grind.")
     elif tone == "struggling":

--- a/backend/core/views.py
+++ b/backend/core/views.py
@@ -334,21 +334,24 @@ def herd_mood_view(request):
     })
 
 
-@api_view(["POST"])
+@api_view(["POST", "GET"])
 @permission_classes([IsAuthenticated])
 def check_badges(request):
-    """Evaluate badge rules for the current user."""
-    new_badges = evaluate_badges(request.user)
+    """Evaluate badge rules for the current user and return badge list."""
+    evaluate_badges(request.user)
+    earned_ids = set(request.user.profile.badges.values_list("id", flat=True))
+    badges = Badge.objects.filter(is_active=True)
     serialized = [
         {
             "code": b.code,
             "name": b.name,
             "emoji": b.emoji,
             "description": b.description,
+            "is_earned": b.id in earned_ids,
         }
-        for b in new_badges
+        for b in badges
     ]
-    return Response({"new_badges": serialized})
+    return Response(serialized)
 
 
 @api_view(["GET"])

--- a/frontend/momentum_flutter/lib/pages/today_page.dart
+++ b/frontend/momentum_flutter/lib/pages/today_page.dart
@@ -201,9 +201,20 @@ class _TodayPageState extends State<TodayPage> {
             else
               Column(
                 crossAxisAlignment: CrossAxisAlignment.start,
-                children: mealPlan.entries
-                    .map((e) => Text('🍽️ ${e.key}: ${e.value}'))
-                    .toList(),
+                children: [
+                  if (mealPlan['breakfast'] != null)
+                    Text('🍳 Breakfast: ${mealPlan['breakfast']}'),
+                  if (mealPlan['lunch'] != null)
+                    Text('🥪 Lunch: ${mealPlan['lunch']}'),
+                  if (mealPlan['dinner'] != null)
+                    Text('🍜 Dinner: ${mealPlan['dinner']}'),
+                  if (mealPlan['snacks'] != null) ...[
+                    const Text('🍏 Snacks:'),
+                    ...List<Widget>.from(
+                      (mealPlan['snacks'] as List).map((s) => Text('• $s')),
+                    ),
+                  ],
+                ],
               ),
           ],
         ),

--- a/frontend/momentum_flutter/lib/services/api_service.dart
+++ b/frontend/momentum_flutter/lib/services/api_service.dart
@@ -32,6 +32,14 @@ class ApiService {
 
   static Future<List<Badge>> fetchBadges() async {
     final token = await TokenService.getToken() ?? '';
+    // ensure badges are evaluated on the server
+    await http.get(
+      Uri.parse('$baseUrl/api/core/check-badges/'),
+      headers: {
+        'Content-Type': 'application/json',
+        if (token.isNotEmpty) 'Authorization': 'Token $token',
+      },
+    );
 
     final response = await http.get(
       Uri.parse('$baseUrl/api/core/badges/'),

--- a/frontend/momentum_flutter/lib/themes/app_theme.dart
+++ b/frontend/momentum_flutter/lib/themes/app_theme.dart
@@ -35,7 +35,7 @@ class AppTheme {
           foregroundColor: Colors.black,
           // Ensure consistent interpolation by matching Flutter defaults
           textStyle:
-              const TextStyle(fontWeight: FontWeight.bold, inherit: false),
+              const TextStyle(fontWeight: FontWeight.bold, inherit: true),
         ),
       ),
       inputDecorationTheme: InputDecorationTheme(


### PR DESCRIPTION
## Summary
- restructure meal plan display on dashboard
- clean recap emoji text
- allow GET on `/check-badges/` and refresh badges before fetch
- call badge check API from Flutter
- fix TextStyle inheritance in theme

## Testing
- `make test-backend` *(fails: OPENAI_API_KEY missing)*
- `make test-frontend` *(fails: flutter not installed)*

------
https://chatgpt.com/codex/tasks/task_e_68518bc513c88323ab7822694fe340bf