### PR TITLE
Ensure auth on viewsets

### DIFF
--- a/backend/content/views.py
+++ b/backend/content/views.py
@@ -14,13 +14,19 @@ from .utils.meme_engine import fetch_donkey_gif, generate_meme_caption
 
 
 class GeneratedImageViewSet(viewsets.ModelViewSet):
+    """CRUD operations for generated images."""
+
     queryset = GeneratedImage.objects.all()
     serializer_class = GeneratedImageSerializer
+    permission_classes = [IsAuthenticated]
 
 
 class SocialPostViewSet(viewsets.ModelViewSet):
+    """Manage links to memes shared on social platforms."""
+
     queryset = SocialPost.objects.all()
     serializer_class = SocialPostSerializer
+    permission_classes = [IsAuthenticated]
 
 
 @api_view(["POST"])

--- a/backend/movement/views.py
+++ b/backend/movement/views.py
@@ -1,14 +1,21 @@
 from rest_framework import viewsets
+from rest_framework.permissions import IsAuthenticated
 
 from .models import MovementChallenge, MovementSession
 from .serializers import MovementChallengeSerializer, MovementSessionSerializer
 
 
 class MovementChallengeViewSet(viewsets.ModelViewSet):
+    """API for creating and updating movement challenges."""
+
     queryset = MovementChallenge.objects.all()
     serializer_class = MovementChallengeSerializer
+    permission_classes = [IsAuthenticated]
 
 
 class MovementSessionViewSet(viewsets.ModelViewSet):
+    """Track a user's individual movement sessions."""
+
     queryset = MovementSession.objects.all()
     serializer_class = MovementSessionSerializer
+    permission_classes = [IsAuthenticated]

--- a/backend/prompts/views.py
+++ b/backend/prompts/views.py
@@ -1,14 +1,21 @@
 from rest_framework import viewsets
+from rest_framework.permissions import IsAuthenticated
 
 from .models import Prompt, PromptResponse
 from .serializers import PromptSerializer, PromptResponseSerializer
 
 
 class PromptViewSet(viewsets.ModelViewSet):
+    """Manage prompt templates for AI interactions."""
+
     queryset = Prompt.objects.all()
     serializer_class = PromptSerializer
+    permission_classes = [IsAuthenticated]
 
 
 class PromptResponseViewSet(viewsets.ModelViewSet):
+    """Store user submissions generated from prompts."""
+
     queryset = PromptResponse.objects.all()
     serializer_class = PromptResponseSerializer
+    permission_classes = [IsAuthenticated]


### PR DESCRIPTION
## Summary
- add authenticated permissions to DRF viewsets
- document each class briefly

## Testing
- `python manage.py test` *(fails: Django not installed)*
- `flake8` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6851f3beae18832385cea357b86df0d0