### PR TITLE
Make Flutter API base URL configurable

### DIFF
--- a/frontend/momentum_flutter/README.md
+++ b/frontend/momentum_flutter/README.md
@@ -14,3 +14,15 @@ A few resources to get you started if this is your first Flutter project:
 For help getting started with Flutter development, view the
 [online documentation](https://docs.flutter.dev/), which offers tutorials,
 samples, guidance on mobile development, and a full API reference.
+
+## Configuration
+
+The app reads the API base URL from the `API_BASE_URL` environment variable.
+When running locally you can override it with:
+
+```bash
+flutter run --dart-define=API_BASE_URL=http://localhost:8000
+```
+
+If you programmatically embed the app you may also supply a `baseUrl` argument
+to `main()` which will take precedence.

--- a/frontend/momentum_flutter/lib/config.dart
+++ b/frontend/momentum_flutter/lib/config.dart
@@ -1,3 +1,17 @@
 class AppConfig {
-  static String baseUrl = 'http://localhost:8000';
+  /// Base URL for all API calls.
+  ///
+  /// The value is resolved in the following order:
+  /// 1. The [baseUrl] provided to the constructor.
+  /// 2. The compile-time environment variable `API_BASE_URL` supplied via
+  ///    `--dart-define`.
+  /// 3. Defaults to `http://localhost:8000`.
+  AppConfig({String? baseUrl}) {
+    AppConfig.baseUrl = baseUrl ??
+        const String.fromEnvironment('API_BASE_URL',
+            defaultValue: 'http://localhost:8000');
+  }
+
+  /// Current API base URL used throughout the application.
+  static late String baseUrl;
 }

--- a/frontend/momentum_flutter/lib/main.dart
+++ b/frontend/momentum_flutter/lib/main.dart
@@ -13,9 +13,8 @@ import 'config.dart';
 
 
 void main({String? baseUrl}) {
-  if (baseUrl != null) {
-    AppConfig.baseUrl = baseUrl;
-  }
+  // Initialize global configuration.
+  AppConfig(baseUrl: baseUrl);
   runApp(const MyApp());
 }
 


### PR DESCRIPTION
## Summary
- allow `AppConfig` to resolve `baseUrl` from constructor or `API_BASE_URL` env variable
- initialize configuration in `main`
- document how to set the API URL for the Flutter app

## Testing
- `make lint-frontend` *(fails: flutter not installed)*

------
https://chatgpt.com/codex/tasks/task_e_6851f3bfa040832381b2231410624c7c