### PR TITLE
Fix login/registration routing

### DIFF
--- a/frontend/momentum_flutter/lib/pages/login_page.dart
+++ b/frontend/momentum_flutter/lib/pages/login_page.dart
@@ -3,7 +3,7 @@ import 'package:flutter/material.dart';
 import '../services/api_service.dart';
 import '../services/token_service.dart';
 import 'register_page.dart';
-import 'today_page.dart';
+import '../main.dart';
 
 class LoginPage extends StatefulWidget {
   const LoginPage({super.key});
@@ -31,7 +31,7 @@ class _LoginPageState extends State<LoginPage> {
       if (!mounted) return;
       Navigator.pushReplacement(
         context,
-        MaterialPageRoute(builder: (_) => const TodayPage()),
+        MaterialPageRoute(builder: (_) => const MyApp()),
       );
     } catch (e) {
       setState(() => _error = 'Login failed');

--- a/frontend/momentum_flutter/lib/pages/register_page.dart
+++ b/frontend/momentum_flutter/lib/pages/register_page.dart
@@ -2,7 +2,7 @@ import 'package:flutter/material.dart';
 
 import '../services/api_service.dart';
 import 'login_page.dart';
-import 'today_page.dart';
+import '../main.dart';
 
 class RegisterPage extends StatefulWidget {
   const RegisterPage({super.key});
@@ -34,7 +34,7 @@ class _RegisterPageState extends State<RegisterPage> {
       if (!mounted) return;
       Navigator.pushReplacement(
         context,
-        MaterialPageRoute(builder: (_) => const TodayPage()),
+        MaterialPageRoute(builder: (_) => const MyApp()),
       );
     } catch (e) {
       setState(() => _error = 'Registration failed');


### PR DESCRIPTION
## Summary
- direct users back to `MyApp` after login and registration so `_determineHome()` runs

## Testing
- `make lint-frontend` *(fails: `flutter` not found)*
- `make test-backend` *(fails: `celery` missing)*
- `make test-frontend` *(fails: `flutter` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6851f3c0d8fc832382115d52999731f3