### PR TITLE
Add Flutter plugin ignores

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,7 @@ backend/db.sqlite3
 
 backend/.venv/
 .venv/
+
+# Flutter project generated files
+.flutter-plugins
+.flutter-plugins-dependencies


### PR DESCRIPTION
## Summary
- add lines for `.flutter-plugins` and `.flutter-plugins-dependencies` to `.gitignore`

## Testing
- `make test-backend` *(fails: ModuleNotFoundError: No module named 'celery')*
- `make test-frontend` *(fails: `flutter` command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6851f3c53e2c832392e9dc97ac203d47