### PR TITLE
Wire API views to Celery tasks

### DIFF
--- a/backend/content/views.py
+++ b/backend/content/views.py
@@ -12,6 +12,11 @@ from .serializers import (
 from .utils.caption_engine import generate_caption
 from .utils.meme_engine import fetch_donkey_gif, generate_meme_caption
 
+try:  # Celery tasks may not be available in dev
+    from core.tasks import generate_meme_task
+except Exception:  # pragma: no cover - fallback when Celery missing
+    generate_meme_task = None
+
 
 class GeneratedImageViewSet(viewsets.ModelViewSet):
     queryset = GeneratedImage.objects.all()
@@ -38,8 +43,19 @@ def generate_meme(request):
     """Generate a donkey meme and store it."""
 
     tone = request.data.get("tone", "funny")
-    image_url = fetch_donkey_gif()
-    caption = generate_meme_caption(tone)
+
+    if generate_meme_task:
+        try:
+            result = generate_meme_task.delay(tone)
+            data = result.get(timeout=15)
+            image_url = data.get("image_url")
+            caption = data.get("caption")
+        except Exception:  # pragma: no cover - worker or broker failure
+            image_url = fetch_donkey_gif()
+            caption = generate_meme_caption(tone)
+    else:
+        image_url = fetch_donkey_gif()
+        caption = generate_meme_caption(tone)
 
     meme = GeneratedMeme.objects.create(
         user=request.user, image_url=image_url, caption=caption, tone=tone


### PR DESCRIPTION
## Summary
- call `generate_meme_task` from `generate_meme` view with fallback
- call `generate_plan_task` & `generate_meal_plan_task` from workout and meal plan views with fallback

## Testing
- `make test-backend`
- `make lint-backend` *(fails: E501 line too long, unused imports)*

------
https://chatgpt.com/codex/tasks/task_e_6851f3c64c7c8323bd86e74c8592458e