### PR TITLE
Refactor daily goal API usage

### DIFF
--- a/frontend/momentum_flutter/lib/pages/today_page.dart
+++ b/frontend/momentum_flutter/lib/pages/today_page.dart
@@ -3,6 +3,7 @@ import 'package:intl/intl.dart';
 
 import '../models/today_dashboard.dart';
 import '../services/api_service.dart';
+import '../models/daily_goal.dart';
 import 'badge_grid_page.dart';
 import '../utils/text_utils.dart';
 import 'herd_feed_page.dart';
@@ -23,7 +24,7 @@ class TodayPage extends StatefulWidget {
 class _TodayPageState extends State<TodayPage> {
   late Future<TodayDashboard> _future;
 
-  Map<String, dynamic>? _dailyGoal;
+  DailyGoal? _dailyGoal;
 
   final TextEditingController _goalController = TextEditingController();
   final TextEditingController _targetController = TextEditingController(text: '1');
@@ -177,7 +178,7 @@ class _TodayPageState extends State<TodayPage> {
     await ApiService.setDailyGoal(goal, target);
     if (mounted) {
       setState(() {
-        _dailyGoal = {'goal': goal, 'target': target};
+        _dailyGoal = DailyGoal(goal: goal, target: target, type: 'daily');
       });
     }
   }
@@ -210,7 +211,7 @@ class _TodayPageState extends State<TodayPage> {
               Padding(
                 padding: const EdgeInsets.only(top: 8),
                 child: Text(
-                    'Today\'s goal: ${_dailyGoal!['goal']} x${_dailyGoal!['target']}'),
+                    'Today\'s goal: ${_dailyGoal!.goal} x${_dailyGoal!.target}'),
               ),
           ],
         ),

--- a/frontend/momentum_flutter/lib/services/api_service.dart
+++ b/frontend/momentum_flutter/lib/services/api_service.dart
@@ -117,27 +117,6 @@ class ApiService {
     return UserProfile.fromJson(data);
   }
 
-  static Future<DailyGoal?> getDailyGoal() async {
-    final token = await TokenService.getToken() ?? '';
-
-    final response = await http.get(
-      Uri.parse('$baseUrl/api/core/daily-goal/'),
-      headers: {
-        'Content-Type': 'application/json',
-        if (token.isNotEmpty) 'Authorization': 'Token $token',
-      },
-    );
-
-    if (response.statusCode != 200) {
-      return null;
-    }
-
-    final data = json.decode(response.body);
-    if (data is Map<String, dynamic> && data.isNotEmpty) {
-      return DailyGoal.fromJson(data);
-    }
-    return null;
-  }
 
   static Future<DailyGoal> setDailyGoal(String goal, int target) async {
     final token = await TokenService.getToken() ?? '';
@@ -173,7 +152,7 @@ class ApiService {
     return Meme.fromJson(jsonData);
   }
 
-  static Future<Map<String, dynamic>?> fetchDailyGoal() async {
+  static Future<DailyGoal?> fetchDailyGoal() async {
     final token = await TokenService.getToken() ?? '';
     final response = await http.get(
       Uri.parse('$baseUrl/api/core/daily-goal/'),
@@ -185,9 +164,11 @@ class ApiService {
     if (response.statusCode != 200) {
       return null;
     }
-    final data = json.decode(response.body) as Map<String, dynamic>;
-    if (data['goal'] == null) return null;
-    return data;
+    final data = json.decode(response.body);
+    if (data is Map<String, dynamic> && data['goal'] != null) {
+      return DailyGoal.fromJson(data);
+    }
+    return null;
   }
 
   // static Future<void> setDailyGoal(String goal, int target) async {


### PR DESCRIPTION
## Summary
- remove the unused `getDailyGoal` API method
- standardize `fetchDailyGoal` to return a `DailyGoal`
- update Today page to use typed goal model

## Testing
- `pytest backend`
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6852d6d7b490832389234e455ebdfc32