### PR TITLE
Implement badge sharing endpoint

### DIFF
--- a/frontend/momentum_flutter/lib/pages/badge_grid_page.dart
+++ b/frontend/momentum_flutter/lib/pages/badge_grid_page.dart
@@ -48,16 +48,21 @@ class _BadgeGridPageState extends State<BadgeGridPage> {
           if (badge.isEarned)
             TextButton(
               onPressed: () async {
-                await ApiService.shareToHerd({
-                  'type': 'badge',
-                  'emoji': badge.emoji,
-                  'badge_name': badge.name,
-                });
-                if (context.mounted) {
-                  Navigator.of(context).pop();
-                  ScaffoldMessenger.of(context).showSnackBar(
-                    const SnackBar(content: Text('Badge shared with the herd 🫏📣')),
-                  );
+                try {
+                  final message = await ApiService.shareBadge(badge.code);
+                  if (context.mounted) {
+                    Navigator.of(context).pop();
+                    ScaffoldMessenger.of(context).showSnackBar(
+                      SnackBar(content: Text(message)),
+                    );
+                  }
+                } catch (e) {
+                  if (context.mounted) {
+                    Navigator.of(context).pop();
+                    ScaffoldMessenger.of(context).showSnackBar(
+                      const SnackBar(content: Text('Failed to share badge')),
+                    );
+                  }
                 }
               },
               child: const Text('📣 Share to Herd'),

--- a/frontend/momentum_flutter/lib/services/api_service.dart
+++ b/frontend/momentum_flutter/lib/services/api_service.dart
@@ -231,6 +231,23 @@ class ApiService {
     return token;
   }
 
+  static Future<String> shareBadge(String badgeCode, {String message = ''}) async {
+    final token = await TokenService.getToken() ?? '';
+    final response = await http.post(
+      Uri.parse('$baseUrl/api/core/share-badge/'),
+      headers: {
+        'Content-Type': 'application/json',
+        if (token.isNotEmpty) 'Authorization': 'Token $token',
+      },
+      body: json.encode({'badge_code': badgeCode, 'message': message}),
+    );
+    if (response.statusCode != 200) {
+      throw Exception('Failed to share badge');
+    }
+    final data = json.decode(response.body) as Map<String, dynamic>;
+    return data['message'] as String? ?? 'Badge shared.';
+  }
+
   static Future<void> shareToHerd(Map<String, dynamic> data) async {
     final token = await TokenService.getToken();
     await http.post(


### PR DESCRIPTION
## Summary
- add ApiService.shareBadge for new `/share-badge/` endpoint
- call `shareBadge` from `BadgeGridPage` and report success or failure

## Testing
- `make test-backend`
- `make test-frontend` *(fails: flutter not installed)*

------
https://chatgpt.com/codex/tasks/task_e_6852d6db285883238839e57c60768c3e