### PR TITLE
Add additional unit tests

### DIFF
--- a/backend/content/tests.py
+++ b/backend/content/tests.py
@@ -1,3 +1,37 @@
-from django.test import TestCase
+from django.contrib.auth.models import User
+from rest_framework.test import APITestCase
+from unittest.mock import patch
 
-# Create your tests here.
+from .models import GeneratedMeme
+
+
+class ContentAPITest(APITestCase):
+    def setUp(self):
+        self.user = User.objects.create_user(username="connie", password="pass")
+        self.client.login(username="connie", password="pass")
+
+    def test_generate_prompt_caption(self):
+        with patch("content.views.generate_caption") as mock_cap:
+            mock_cap.return_value = "so funny"
+            resp = self.client.post(
+                "/api/content/generate-caption/",
+                {"description": "test", "tone": "funny"},
+                format="json",
+            )
+
+        self.assertEqual(resp.status_code, 200)
+        self.assertEqual(resp.data["caption"], "so funny")
+
+    def test_generate_meme(self):
+        with patch("content.views.fetch_donkey_gif") as gif_mock, patch(
+            "content.views.generate_meme_caption"
+        ) as caption_mock:
+            gif_mock.return_value = "http://gif"
+            caption_mock.return_value = "roast"
+            resp = self.client.post("/api/content/generate-meme/", {}, format="json")
+
+        self.assertEqual(resp.status_code, 200)
+        self.assertEqual(resp.data["image_url"], "http://gif")
+        self.assertEqual(resp.data["caption"], "roast")
+        self.assertEqual(GeneratedMeme.objects.count(), 1)
+

--- a/backend/movement/tests.py
+++ b/backend/movement/tests.py
@@ -1,3 +1,35 @@
-from django.test import TestCase
+from django.contrib.auth.models import User
+from django.utils import timezone
+from rest_framework.test import APITestCase
 
-# Create your tests here.
+
+class MovementAPITest(APITestCase):
+    def setUp(self):
+        self.user = User.objects.create_user(username="mover", password="pass")
+        self.client.login(username="mover", password="pass")
+
+    def test_create_challenge_and_session(self):
+        chal_resp = self.client.post(
+            "/api/movement/challenges/",
+            {"title": "Run", "description": "fast", "duration_minutes": 5},
+            format="json",
+        )
+        self.assertEqual(chal_resp.status_code, 201)
+        challenge_id = chal_resp.data["id"]
+
+        sess_payload = {
+            "user": self.user.id,
+            "challenge": challenge_id,
+            "duration": 5,
+            "start_time": timezone.now().isoformat(),
+            "end_time": (timezone.now() + timezone.timedelta(minutes=5)).isoformat(),
+            "is_complete": True,
+        }
+
+        sess_resp = self.client.post(
+            "/api/movement/sessions/", sess_payload, format="json"
+        )
+        self.assertEqual(sess_resp.status_code, 201)
+        self.assertEqual(sess_resp.data["challenge"], challenge_id)
+        self.assertEqual(sess_resp.data["user"], self.user.id)
+

--- a/backend/prompts/tests.py
+++ b/backend/prompts/tests.py
@@ -1,3 +1,32 @@
-from django.test import TestCase
+from django.contrib.auth.models import User
+from rest_framework.test import APITestCase
 
-# Create your tests here.
+
+class PromptsAPITest(APITestCase):
+    def setUp(self):
+        self.user = User.objects.create_user(username="pro", password="pass")
+        self.client.login(username="pro", password="pass")
+
+    def test_prompt_and_response(self):
+        p_resp = self.client.post(
+            "/api/prompts/prompts/",
+            {"text": "Do it", "category": "test"},
+            format="json",
+        )
+        self.assertEqual(p_resp.status_code, 201)
+        pid = p_resp.data["id"]
+
+        r_resp = self.client.post(
+            "/api/prompts/responses/",
+            {
+                "prompt": pid,
+                "user": self.user.id,
+                "image_url": "http://example.com/img.png",
+                "caption": "cap",
+            },
+            format="json",
+        )
+        self.assertEqual(r_resp.status_code, 201)
+        self.assertEqual(r_resp.data["prompt"], pid)
+        self.assertEqual(r_resp.data["user"], self.user.id)
+

--- a/frontend/momentum_flutter/test/herd_feed_page_test.dart
+++ b/frontend/momentum_flutter/test/herd_feed_page_test.dart
@@ -1,0 +1,19 @@
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:momentum_flutter/pages/herd_feed_page.dart';
+
+void main() {
+  const MethodChannel channel = MethodChannel('plugins.flutter.io/flutter_secure_storage');
+  TestWidgetsFlutterBinding.ensureInitialized();
+  channel.setMockMethodCallHandler((MethodCall methodCall) async {
+    return null;
+  });
+
+  testWidgets('HerdFeedPage has title', (WidgetTester tester) async {
+    await tester.pumpWidget(const MaterialApp(home: HerdFeedPage()));
+    await tester.pump();
+
+    expect(find.text('Herd Feed 🫏'), findsOneWidget);
+  });
+}

--- a/frontend/momentum_flutter/test/profile_page_test.dart
+++ b/frontend/momentum_flutter/test/profile_page_test.dart
@@ -1,0 +1,19 @@
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:momentum_flutter/pages/profile_page.dart';
+
+void main() {
+  const MethodChannel channel = MethodChannel('plugins.flutter.io/flutter_secure_storage');
+  TestWidgetsFlutterBinding.ensureInitialized();
+  channel.setMockMethodCallHandler((MethodCall methodCall) async {
+    return null;
+  });
+
+  testWidgets('ProfilePage shows header text', (WidgetTester tester) async {
+    await tester.pumpWidget(const MaterialApp(home: ProfilePage()));
+    await tester.pump();
+
+    expect(find.text('My Profile 🫏'), findsOneWidget);
+  });
+}

--- a/frontend/momentum_flutter/test/today_page_test.dart
+++ b/frontend/momentum_flutter/test/today_page_test.dart
@@ -1,0 +1,20 @@
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:momentum_flutter/pages/today_page.dart';
+
+void main() {
+  const MethodChannel channel = MethodChannel('plugins.flutter.io/flutter_secure_storage');
+  TestWidgetsFlutterBinding.ensureInitialized();
+  channel.setMockMethodCallHandler((MethodCall methodCall) async {
+    return null;
+  });
+
+  testWidgets('TodayPage renders basic widgets', (WidgetTester tester) async {
+    await tester.pumpWidget(const MaterialApp(home: TodayPage()));
+    await tester.pump();
+
+    expect(find.text('MoveYourAzz 🫏'), findsOneWidget);
+    expect(find.byType(FloatingActionButton), findsOneWidget);
+  });
+}


### PR DESCRIPTION
## Summary
- expand backend test coverage for the `content`, `movement`, and `prompts` apps
- add widget tests for `TodayPage`, `ProfilePage`, and `HerdFeedPage`

## Testing
- `make test-backend`
- `make test-frontend` *(fails: `flutter` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6852d6dc42d883239aeb5e95e6d319b6