### PR TITLE
Fix voice journal page with AudioRecorder

### DIFF
--- a/frontend/momentum_flutter/lib/pages/voice_journal_page.dart
+++ b/frontend/momentum_flutter/lib/pages/voice_journal_page.dart
@@ -17,7 +17,7 @@ class VoiceJournalPage extends StatefulWidget {
 }
 
 class _VoiceJournalPageState extends State<VoiceJournalPage> {
-  final Record _record = Record();
+  final AudioRecorder _record = AudioRecorder();
   final AudioPlayer _player = AudioPlayer();
 
   bool _isRecording = false;


### PR DESCRIPTION
## Summary
- migrate voice journal to use `AudioRecorder` from `record` 5.x

## Testing
- `make lint-frontend` *(fails: `flutter` not found)*
- `make test-frontend` *(fails: `flutter` not found)*
- `make lint-backend` *(fails: `flake8` not found)*
- `make test-backend` *(fails: AttributeError and AssertionError)*

------
https://chatgpt.com/codex/tasks/task_e_6852dd8c2c3c832383c421dc675de329