### PR TITLE
Fix voice journal recording path

### DIFF
--- a/frontend/momentum_flutter/lib/pages/voice_journal_page.dart
+++ b/frontend/momentum_flutter/lib/pages/voice_journal_page.dart
@@ -2,6 +2,7 @@ import 'dart:io';
 
 import 'package:flutter/material.dart';
 import 'package:record/record.dart';
+import 'package:path_provider/path_provider.dart';
 import 'package:audioplayers/audioplayers.dart';
 
 import '../services/api_service.dart';
@@ -28,7 +29,10 @@ class _VoiceJournalPageState extends State<VoiceJournalPage> {
 
   Future<void> _startRecording() async {
     if (await _record.hasPermission()) {
-      await _record.start(const RecordConfig());
+      final dir = await getTemporaryDirectory();
+      final filePath =
+          '${dir.path}/journal_${DateTime.now().millisecondsSinceEpoch}.m4a';
+      await _record.start(const RecordConfig(), path: filePath);
       setState(() => _isRecording = true);
     }
   }

--- a/frontend/momentum_flutter/pubspec.yaml
+++ b/frontend/momentum_flutter/pubspec.yaml
@@ -41,6 +41,7 @@ dependencies:
   gallery_saver: ^2.3.2
   record: ^5.0.0
   audioplayers: ^5.2.0
+  path_provider: ^2.1.5
 
   # The following adds the Cupertino Icons font to your application.
   # Use with the CupertinoIcons class for iOS style icons.


### PR DESCRIPTION
## Summary
- configure audio recording path using `getTemporaryDirectory`
- add `path_provider` dependency

## Testing
- `make lint-frontend` *(fails: `flutter` not found)*
- `make test-frontend` *(fails: `flutter` not found)*
- `make lint-backend` *(fails: `flake8` not found)*
- `make test-backend` *(fails: tests fail)*

------
https://chatgpt.com/codex/tasks/task_e_6852e0ca1a50832399c536479e53e989