### PR TITLE
Fix profile auth flow

### DIFF
--- a/frontend/momentum_flutter/lib/main.dart
+++ b/frontend/momentum_flutter/lib/main.dart
@@ -50,8 +50,8 @@ class MyApp extends StatelessWidget {
   }
 
   Future<Widget> _determineHome() async {
-    final loggedIn = await TokenService.isAuthenticated();
-    if (!loggedIn) return const LoginPage();
+    final token = await TokenService.getToken();
+    if (token == null || token.isEmpty) return const LoginPage();
 
     final profile = await ApiService.fetchProfile();
     if (profile.displayName.isEmpty) return const ProfilePage();

--- a/frontend/momentum_flutter/lib/services/api_service.dart
+++ b/frontend/momentum_flutter/lib/services/api_service.dart
@@ -86,7 +86,7 @@ class ApiService {
       Uri.parse('$baseUrl/api/core/profile/'),
       headers: {
         'Content-Type': 'application/json',
-        if (token.isNotEmpty) 'Authorization': 'Token $token',
+        'Authorization': 'Token $token',
       },
     );
 

--- a/frontend/momentum_flutter/lib/services/token_service.dart
+++ b/frontend/momentum_flutter/lib/services/token_service.dart
@@ -3,16 +3,21 @@ import 'package:flutter_secure_storage/flutter_secure_storage.dart';
 class TokenService {
   static final _storage = const FlutterSecureStorage();
   static const _tokenKey = 'auth_token';
+  static String? _cachedToken;
 
   static Future<void> saveToken(String token) async {
+    _cachedToken = token;
     await _storage.write(key: _tokenKey, value: token);
   }
 
   static Future<String?> getToken() async {
-    return await _storage.read(key: _tokenKey);
+    if (_cachedToken != null) return _cachedToken;
+    _cachedToken = await _storage.read(key: _tokenKey);
+    return _cachedToken;
   }
 
   static Future<void> clearToken() async {
+    _cachedToken = null;
     await _storage.delete(key: _tokenKey);
   }
 


### PR DESCRIPTION
## Summary
- cache auth token in TokenService to avoid race conditions
- check for a saved token in _determineHome before loading profile
- always send auth header when fetching profile

## Testing
- `make test-backend` *(fails: AttributeError in content.tests, fail in movement.tests)*
- `make test-frontend` *(fails: flutter not found)*

------
https://chatgpt.com/codex/tasks/task_e_6853064492388323a24b248dc5ac0880