### PR TITLE
Implement logout API and flutter logic

### DIFF
--- a/backend/content/urls.py
+++ b/backend/content/urls.py
@@ -4,6 +4,7 @@ from .views import (
     GeneratedImageViewSet,
     SocialPostViewSet,
     generate_meme,
+    generate_caption_view,
 )
 
 router = DefaultRouter()
@@ -11,5 +12,6 @@ router.register(r'images', GeneratedImageViewSet)
 router.register(r'social-posts', SocialPostViewSet)
 
 urlpatterns = router.urls + [
+    path("generate-caption/", generate_caption_view),
     path("generate-meme/", generate_meme),
 ]

--- a/backend/content/views.py
+++ b/backend/content/views.py
@@ -2,6 +2,7 @@ from rest_framework import viewsets
 from rest_framework.decorators import api_view, permission_classes
 from rest_framework.permissions import IsAuthenticated
 from rest_framework.response import Response
+from rest_framework.decorators import api_view, permission_classes
 
 from .models import GeneratedImage, SocialPost, GeneratedMeme
 from .serializers import (
@@ -10,6 +11,7 @@ from .serializers import (
     GeneratedMemeSerializer,
 )
 from .utils.meme_engine import fetch_donkey_gif, generate_meme_caption
+from .utils.caption_engine import generate_caption
 
 try:  # Celery tasks may not be available in dev
     from core.tasks import generate_meme_task
@@ -33,6 +35,16 @@ class SocialPostViewSet(viewsets.ModelViewSet):
     queryset = SocialPost.objects.all()
     serializer_class = SocialPostSerializer
     permission_classes = [IsAuthenticated]
+
+
+@api_view(["POST"])
+@permission_classes([IsAuthenticated])
+def generate_caption_view(request):
+    """Generate a caption for a description."""
+    description = request.data.get("description", "")
+    tone = request.data.get("tone", "funny")
+    caption = generate_caption(description, tone)
+    return Response({"caption": caption})
 
 
 

--- a/backend/core/tests.py
+++ b/backend/core/tests.py
@@ -24,6 +24,18 @@ class AuthAPITest(APITestCase):
         token = response.data["token"]
         self.assertTrue(Token.objects.filter(key=token).exists())
 
+
+class LogoutAPITest(APITestCase):
+    def setUp(self):
+        self.user = User.objects.create_user(username="gone", password="pass")
+        self.token = Token.objects.create(user=self.user)
+
+    def test_logout(self):
+        self.client.credentials(HTTP_AUTHORIZATION=f"Token {self.token.key}")
+        response = self.client.post("/api/core/logout/")
+        self.assertEqual(response.status_code, 204)
+        self.assertFalse(Token.objects.filter(user=self.user).exists())
+
 class MovementGoalAPITest(APITestCase):
     def setUp(self):
         self.user = User.objects.create_user(username="tester", password="pass")

--- a/backend/core/urls.py
+++ b/backend/core/urls.py
@@ -33,6 +33,7 @@ from .views import (
     herd_feed,
     register_user,
     CustomAuthToken,
+    logout_user,
 )
 
 router = DefaultRouter()
@@ -45,6 +46,7 @@ router.register(r"paddle-logs", PaddleLogViewSet)
 urlpatterns = router.urls + [
     path("register/", register_user),
     path("login/", CustomAuthToken.as_view()),
+    path("logout/", logout_user),
     path("trigger-shame/", trigger_shame_view),
     path("upload-voice/", upload_voice_journal),
     path("create-herd/", create_herd),

--- a/backend/core/views.py
+++ b/backend/core/views.py
@@ -128,6 +128,14 @@ class CustomAuthToken(ObtainAuthToken):
 
 @api_view(["POST"])
 @permission_classes([IsAuthenticated])
+def logout_user(request):
+    """Delete the auth token for the current user."""
+    request.user.auth_token.delete()
+    return Response(status=204)
+
+
+@api_view(["POST"])
+@permission_classes([IsAuthenticated])
 def upload_voice_journal(request):
     audio_file = request.FILES.get("audio_file")
     if not audio_file:

--- a/backend/movement/urls.py
+++ b/backend/movement/urls.py
@@ -1,0 +1,9 @@
+from rest_framework.routers import DefaultRouter
+from django.urls import path
+from .views import MovementChallengeViewSet, MovementSessionViewSet
+
+router = DefaultRouter()
+router.register(r"challenges", MovementChallengeViewSet)
+router.register(r"sessions", MovementSessionViewSet)
+
+urlpatterns = router.urls

--- a/backend/movement/views.py
+++ b/backend/movement/views.py
@@ -1,0 +1,16 @@
+from rest_framework import viewsets
+from rest_framework.permissions import IsAuthenticated
+from .models import MovementChallenge, MovementSession
+from .serializers import MovementChallengeSerializer, MovementSessionSerializer
+
+
+class MovementChallengeViewSet(viewsets.ModelViewSet):
+    queryset = MovementChallenge.objects.all()
+    serializer_class = MovementChallengeSerializer
+    permission_classes = [IsAuthenticated]
+
+
+class MovementSessionViewSet(viewsets.ModelViewSet):
+    queryset = MovementSession.objects.all()
+    serializer_class = MovementSessionSerializer
+    permission_classes = [IsAuthenticated]

--- a/backend/server/urls.py
+++ b/backend/server/urls.py
@@ -25,6 +25,7 @@ urlpatterns = [
     path("api/core/", include("core.urls")),
     path("api/prompts/", include("prompts.urls")),
     path("api/content/", include("content.urls")),
+    path("api/movement/", include("movement.urls")),
 ]
 
 urlpatterns += static(settings.MEDIA_URL, document_root=settings.MEDIA_ROOT)

--- a/frontend/momentum_flutter/lib/pages/profile_page.dart
+++ b/frontend/momentum_flutter/lib/pages/profile_page.dart
@@ -130,6 +130,7 @@ class _ProfilePageState extends State<ProfilePage> {
                 const SizedBox(height: 20),
                 ElevatedButton(
                   onPressed: () async {
+                    await ApiService.logout();
                     await TokenService.clearToken();
                     if (!mounted) return;
                     Navigator.pushReplacement(

--- a/frontend/momentum_flutter/lib/services/api_service.dart
+++ b/frontend/momentum_flutter/lib/services/api_service.dart
@@ -260,4 +260,15 @@ class ApiService {
     final body = await response.stream.bytesToString();
     return json.decode(body) as Map<String, dynamic>;
   }
+
+  static Future<void> logout() async {
+    final token = await TokenService.getToken();
+    await http.post(
+      Uri.parse('$baseUrl/api/core/logout/'),
+      headers: {
+        'Authorization': 'Token $token',
+        'Content-Type': 'application/json',
+      },
+    );
+  }
 }


### PR DESCRIPTION
## Summary
- add backend logout route
- expose caption generation API for tests
- scaffold movement API and wire urls
- add logout test coverage
- call logout endpoint from Flutter profile page

## Testing
- `make test-backend`
- `make lint-backend` *(fails: flake8 not found)*

------
https://chatgpt.com/codex/tasks/task_e_68530a2008d88323bb5a41eb72615355