### PR TITLE
Handle photo permissions for meme saving

### DIFF
--- a/frontend/momentum_flutter/ios/Runner/Info.plist
+++ b/frontend/momentum_flutter/ios/Runner/Info.plist
@@ -51,5 +51,7 @@
         <array>
                 <string>_dartobservatory._tcp</string>
         </array>
+        <key>NSPhotoLibraryAddUsageDescription</key>
+        <string>Allow MoveYourAzz to save memes to your photo library.</string>
 </dict>
 </plist>

--- a/frontend/momentum_flutter/lib/pages/meme_share_page.dart
+++ b/frontend/momentum_flutter/lib/pages/meme_share_page.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:share_plus/share_plus.dart';
 import 'package:gallery_saver/gallery_saver.dart';
+import 'package:permission_handler/permission_handler.dart';
 
 import '../models/meme.dart';
 import '../services/api_service.dart';
@@ -12,6 +13,17 @@ class MemeSharePage extends StatelessWidget {
   const MemeSharePage({required this.meme, Key? key}) : super(key: key);
 
   Future<void> saveMemeToDevice(BuildContext context, Meme meme) async {
+    final status = await Permission.photos.request();
+    if (!status.isGranted) {
+      if (!context.mounted) return;
+      ScaffoldMessenger.of(context).showSnackBar(
+        const SnackBar(
+          content: Text('Please enable photo permissions to save memes.'),
+        ),
+      );
+      return;
+    }
+
     try {
       final bool? result = await GallerySaver.saveImage(meme.imageUrl);
       if (!context.mounted) return;

--- a/frontend/momentum_flutter/pubspec.lock
+++ b/frontend/momentum_flutter/pubspec.lock
@@ -733,6 +733,54 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.1.0"
+  permission_handler:
+    dependency: "direct main"
+    description:
+      name: permission_handler
+      sha256: 2d070d8684b68efb580a5997eb62f675e8a885ef0be6e754fb9ef489c177470f
+      url: "https://pub.dev"
+    source: hosted
+    version: "12.0.0+1"
+  permission_handler_android:
+    dependency: transitive
+    description:
+      name: permission_handler_android
+      sha256: 1e3bc410ca1bf84662104b100eb126e066cb55791b7451307f9708d4007350e6
+      url: "https://pub.dev"
+    source: hosted
+    version: "13.0.1"
+  permission_handler_apple:
+    dependency: transitive
+    description:
+      name: permission_handler_apple
+      sha256: f000131e755c54cf4d84a5d8bd6e4149e262cc31c5a8b1d698de1ac85fa41023
+      url: "https://pub.dev"
+    source: hosted
+    version: "9.4.7"
+  permission_handler_html:
+    dependency: transitive
+    description:
+      name: permission_handler_html
+      sha256: 38f000e83355abb3392140f6bc3030660cfaef189e1f87824facb76300b4ff24
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.1.3+5"
+  permission_handler_platform_interface:
+    dependency: transitive
+    description:
+      name: permission_handler_platform_interface
+      sha256: eb99b295153abce5d683cac8c02e22faab63e50679b937fa1bf67d58bb282878
+      url: "https://pub.dev"
+    source: hosted
+    version: "4.3.0"
+  permission_handler_windows:
+    dependency: transitive
+    description:
+      name: permission_handler_windows
+      sha256: 1a790728016f79a41216d88672dbc5df30e686e811ad4e698bfc51f76ad91f1e
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.2.1"
 sdks:
   dart: ">=3.7.2 <4.0.0"
   flutter: ">=3.27.0"

--- a/frontend/momentum_flutter/pubspec.yaml
+++ b/frontend/momentum_flutter/pubspec.yaml
@@ -42,6 +42,7 @@ dependencies:
   record: ^5.0.0
   audioplayers: ^5.2.0
   path_provider: ^2.1.5
+  permission_handler: ^12.0.0+1
 
   # The following adds the Cupertino Icons font to your application.
   # Use with the CupertinoIcons class for iOS style icons.


### PR DESCRIPTION
## Summary
- check photo permissions with `permission_handler` before saving memes
- show a helpful Snackbar on denial
- document photo library usage for iOS
- include `permission_handler` dependency and lock entries

## Testing
- `make test-backend` *(fails: TypeError and AssertionError)*
- `make test-frontend` *(fails: `flutter` command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685327e515688323ad5bb37023a42549