### PR TITLE
Fix installed apps ordering

### DIFF
--- a/backend/server/settings.py
+++ b/backend/server/settings.py
@@ -40,6 +40,7 @@ CELERY_RESULT_BACKEND = os.getenv("REDIS_URL", "redis://localhost:6379/0")
 # Application definition
 
 INSTALLED_APPS = [
+    "accounts",  # custom user model must come before auth
     "django.contrib.admin",
     "django.contrib.auth",
     "django.contrib.contenttypes",
@@ -50,7 +51,6 @@ INSTALLED_APPS = [
     "rest_framework.authtoken",
     "rest_framework_simplejwt.token_blacklist",
     "corsheaders",
-    "accounts",
     "core",
     "shame",
     "voice_journals",


### PR DESCRIPTION
## Summary
- ensure the custom `accounts` app is loaded before Django auth

## Testing
- `make test-backend` *(fails: TypeError from tests using username field)*

------
https://chatgpt.com/codex/tasks/task_e_685468ca60d8832380ba568186b2fb96