### PR TITLE
Fix Makefile indentation causing error

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -29,7 +29,7 @@ lint-backend:
 
 # == Frontend Commands ==
 run-frontend:
-    cd $(FRONTEND_DIR) && \
+	cd $(FRONTEND_DIR) && \
 	flutter run --disable-vm-service-publication
 
 test-frontend:


### PR DESCRIPTION
## Summary
- use tabs for the `run-frontend` recipe in `Makefile`

## Testing
- `make -n run-frontend`
- `make -n run-backend`


------
https://chatgpt.com/codex/tasks/task_e_6854a33e42288323b68400ea6e422d78