### PR TITLE
Fix backend setup error

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@ __pycache__/
 db.sqlite3
 backend/db.sqlite3
 backend/media/
+backend/static/
 .env
 .venv/
 

--- a/README.md
+++ b/README.md
@@ -5,14 +5,13 @@ This repo contains the Django backend and Flutter frontend projects.
 
 ## Getting Started
 
-1. Copy `.env.sample` to `.env` and fill in the required API keys.
-2. Install backend dependencies and set up a virtual environment:
+1. Copy `backend/.env.sample` to `backend/.env` and fill in the required API
+   keys.
+2. Install backend dependencies and set up a virtual environment (or run
+   `make install-backend` which performs these steps):
 
 ```bash
-cd backend
-python3 -m venv .venv
-source .venv/bin/activate
-pip install -r requirements.txt
+make install-backend
 ```
 
 3. Apply migrations and launch the server:

--- a/backend/.env.sample
+++ b/backend/.env.sample
@@ -1,0 +1,7 @@
+# Sample environment for MoveYourAzz
+SECRET_KEY=changeme
+OPENAI_API_KEY=your-openai-key
+FRONTEND_BASE_URL=http://localhost:8080
+REDIS_URL=redis://localhost:6379/0
+DEBUG=True
+ALLOWED_HOSTS=localhost,127.0.0.1

--- a/backend/server/settings.py
+++ b/backend/server/settings.py
@@ -146,6 +146,7 @@ USE_TZ = True
 # https://docs.djangoproject.com/en/5.2/howto/static-files/
 
 STATIC_URL = "/static/"
+STATIC_ROOT = os.path.join(BASE_DIR, "static")
 STATICFILES_STORAGE = "whitenoise.storage.CompressedManifestStaticFilesStorage"
 MEDIA_URL = "/media/"
 MEDIA_ROOT = os.path.join(BASE_DIR, "media")


### PR DESCRIPTION
## Summary
- configure `STATIC_ROOT` so `collectstatic` succeeds
- add sample environment file for backend
- document using `make install-backend`
- ignore collected static files

## Testing
- `make test-backend`
- `make lint-backend` *(fails: flake8 not found)*
- `make run-backend`

------
https://chatgpt.com/codex/tasks/task_e_6854a4d8ce1883238025508dc94795fc