### PR TITLE
Fix Flutter run flag

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -30,7 +30,7 @@ lint-backend:
 # == Frontend Commands ==
 run-frontend:
 	cd $(FRONTEND_DIR) && \
-	flutter run --disable-vm-service-publication
+	flutter run --no-publish-port
 
 test-frontend:
 	cd $(FRONTEND_DIR) && flutter test


### PR DESCRIPTION
## Summary
- fix `run-frontend` command to use `--no-publish-port`

## Testing
- `make test-backend`
- `make lint-backend` *(fails: flake8 not found)*
- `make lint-frontend` *(fails: flutter not found)*
- `make test-frontend` *(fails: flutter not found)*

------
https://chatgpt.com/codex/tasks/task_e_6854a609c8bc8323b32ef715b3388a7b