### PR TITLE
Fix ElevatedButton text style inheritance

### DIFF
--- a/frontend/momentum_flutter/lib/themes/app_theme.dart
+++ b/frontend/momentum_flutter/lib/themes/app_theme.dart
@@ -33,7 +33,10 @@ class AppTheme {
         style: ElevatedButton.styleFrom(
           backgroundColor: AppColors.donkeyGold,
           foregroundColor: Colors.black,
-          textStyle: const TextStyle(fontWeight: FontWeight.bold),
+          // Ensure `inherit` matches the theme's text styles to avoid
+          // interpolation errors when the button state changes.
+          textStyle:
+              const TextStyle(fontWeight: FontWeight.bold, inherit: false),
         ),
       ),
       outlinedButtonTheme: OutlinedButtonThemeData(


### PR DESCRIPTION
## Summary
- prevent AnimatedDefaultTextStyle interpolation error by aligning button text style inheritance with theme

## Testing
- `make test-backend`
- `make lint-frontend` *(fails: `flutter` not installed)*

------
https://chatgpt.com/codex/tasks/task_e_6854a7f6458c83239120373e815562a9