### PR TITLE
Fix profile endpoint

### DIFF
--- a/frontend/momentum_flutter/lib/services/api_service.dart
+++ b/frontend/momentum_flutter/lib/services/api_service.dart
@@ -75,7 +75,7 @@ class ApiService {
     headers.addAll(await AuthService.authHeaders());
 
     final response = await http.get(
-      Uri.parse('$baseUrl/api/core/profiles/'),
+      Uri.parse('$baseUrl/api/core/profile/'),
       headers: headers,
     );
 


### PR DESCRIPTION
## Summary
- call the singular `profile/` endpoint when fetching user data

## Testing
- `make lint-frontend` *(fails: flutter: command not found)*
- `make test-frontend` *(fails: flutter: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6854ab8d43508323ae542361d1b050ea