### PR TITLE
Handle Flutter app init error

### DIFF
--- a/frontend/momentum_flutter/lib/main.dart
+++ b/frontend/momentum_flutter/lib/main.dart
@@ -30,6 +30,14 @@ class MyApp extends StatelessWidget {
       future: _determineHome(),
 
       builder: (context, snapshot) {
+        if (snapshot.hasError) {
+          return MaterialApp(
+            title: 'MoveYourAzz',
+            theme: AppTheme.theme,
+            home: const LoginPage(),
+          );
+        }
+
         if (!snapshot.hasData) {
           return const MaterialApp(
             home: Scaffold(


### PR DESCRIPTION
## Summary
- return LoginPage from `MyApp` if initialization fails

## Testing
- `make lint-frontend` *(fails: flutter not installed)*
- `make test-frontend` *(fails: flutter not installed)*

------
https://chatgpt.com/codex/tasks/task_e_6854ab9170908323819050c37fc56cfd