### PR TITLE
Fix today dashboard endpoint path

### DIFF
--- a/backend/core/tests.py
+++ b/backend/core/tests.py
@@ -199,7 +199,7 @@ class DashboardTodayAPITest(APITestCase):
                 "snacks": ["nuts"],
             }
 
-            response = self.client.get("/api/core/dashboard-today/")
+            response = self.client.get("/api/core/dashboard/")
 
         self.assertEqual(response.status_code, 200)
         self.assertIn("mood", response.data)

--- a/frontend/momentum_flutter/lib/services/api_service.dart
+++ b/frontend/momentum_flutter/lib/services/api_service.dart
@@ -19,7 +19,7 @@ class ApiService {
     headers.addAll(await AuthService.authHeaders());
 
     final response = await http.get(
-      Uri.parse('$baseUrl/api/core/dashboard-today/'),
+      Uri.parse('$baseUrl/api/core/dashboard/'),
       headers: headers,
     );
 


### PR DESCRIPTION
## Summary
- point Today dashboard to `/api/core/dashboard/`
- update backend test path

## Testing
- `make test-backend`
- `make test-frontend` *(fails: flutter not installed)*

------
https://chatgpt.com/codex/tasks/task_e_6854ab8f7f98832396fcbc4763501adf