### PR TITLE
Fix mobile registration base URL

### DIFF
--- a/frontend/momentum_flutter/README.md
+++ b/frontend/momentum_flutter/README.md
@@ -24,5 +24,12 @@ When running locally you can override it with:
 flutter run --dart-define=API_BASE_URL=http://localhost:8000
 ```
 
+When running on the Android emulator `localhost` points to the emulator
+itself. Use the special host `10.0.2.2` to reach your machine:
+
+```bash
+flutter run --dart-define=API_BASE_URL=http://10.0.2.2:8000
+```
+
 If you programmatically embed the app you may also supply a `baseUrl` argument
 to `main()` which will take precedence.

--- a/frontend/momentum_flutter/lib/config.dart
+++ b/frontend/momentum_flutter/lib/config.dart
@@ -1,3 +1,6 @@
+import 'dart:io' show Platform;
+import 'package:flutter/foundation.dart';
+
 class AppConfig {
   /// Base URL for all API calls.
   ///
@@ -5,11 +8,20 @@ class AppConfig {
   /// 1. The [baseUrl] provided to the constructor.
   /// 2. The compile-time environment variable `API_BASE_URL` supplied via
   ///    `--dart-define`.
-  /// 3. Defaults to `http://localhost:8000`.
+  /// 3. Defaults to `http://localhost:8000` (or `http://10.0.2.2:8000` on the
+  ///    Android emulator).
   AppConfig({String? baseUrl}) {
-    AppConfig.baseUrl = baseUrl ??
-        const String.fromEnvironment('API_BASE_URL',
-            defaultValue: 'http://localhost:8000');
+    AppConfig.baseUrl =
+        baseUrl ?? const String.fromEnvironment('API_BASE_URL', defaultValue: _defaultBaseUrl);
+  }
+
+  static String get _defaultBaseUrl {
+    if (!kIsWeb && Platform.isAndroid) {
+      // 'localhost' refers to the device itself when running on the Android
+      // emulator. `10.0.2.2` routes to the host machine instead.
+      return 'http://10.0.2.2:8000';
+    }
+    return 'http://localhost:8000';
   }
 
   /// Current API base URL used throughout the application.


### PR DESCRIPTION
## Summary
- default Android emulator base URL to 10.0.2.2
- mention Android emulator base URL in README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6854cf39b6888323ad852064b71bf977