### PR TITLE
Add vision identification MVP

### DIFF
--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -36,3 +36,4 @@ whitenoise==6.6.0
 black==25.1.0
 isort==6.0.1
 flake8==7.2.0
+django-ratelimit==3.0.1

--- a/backend/server/settings.py
+++ b/backend/server/settings.py
@@ -60,6 +60,7 @@ INSTALLED_APPS = [
     "prompts",
     "movement",
     "content",
+    "vision",
     "django_celery_results",
 ]
 

--- a/backend/server/urls.py
+++ b/backend/server/urls.py
@@ -13,6 +13,7 @@ urlpatterns = [
     path("api/prompts/", include("prompts.urls")),
     path("api/content/", include("content.urls")),
     path("api/movement/", include("movement.urls")),
+    path("api/vision/", include("vision.urls")),
 ]
 
 urlpatterns += static(settings.MEDIA_URL, document_root=settings.MEDIA_ROOT)

--- a/backend/vision/__init__.py
+++ b/backend/vision/__init__.py
@@ -1,0 +1,1 @@
+default_app_config = "vision.apps.VisionConfig"

--- a/backend/vision/apps.py
+++ b/backend/vision/apps.py
@@ -1,0 +1,6 @@
+from django.apps import AppConfig
+
+
+class VisionConfig(AppConfig):
+    default_auto_field = "django.db.models.BigAutoField"
+    name = "vision"

--- a/backend/vision/tasks.py
+++ b/backend/vision/tasks.py
@@ -1,0 +1,48 @@
+import base64
+import requests
+from celery import shared_task
+from django.conf import settings
+
+
+@shared_task(bind=True, max_retries=3)
+def identify_image_task(self, task_id: str, image_path: str):
+    """Identify the image using OpenAI Vision or Gemini."""
+    label = "unknown"
+    try:
+        with open(image_path, "rb") as f:
+            data = base64.b64encode(f.read()).decode()
+        payload = {
+            "model": "gpt-4-vision-preview",
+            "messages": [
+                {
+                    "role": "user",
+                    "content": [
+                        {"type": "text", "text": "Identify the primary subject"},
+                        {"type": "image_url", "image_url": {"url": f"data:image/jpeg;base64,{data}"}},
+                    ],
+                }
+            ],
+            "max_tokens": 5,
+        }
+        headers = {"Authorization": f"Bearer {settings.OPENAI_API_KEY}"}
+        res = requests.post("https://api.openai.com/v1/chat/completions", json=payload, headers=headers, timeout=20)
+        label = res.json()["choices"][0]["message"]["content"].strip().split("\n")[0]
+    except Exception:
+        pass
+    is_dangerous = label.lower() in [
+        "rattlesnake",
+        "cobra",
+        "mountain lion",
+        "poison ivy",
+    ]
+    wiki_url = ""
+    try:
+        wiki_res = requests.get(
+            f"https://en.wikipedia.org/api/rest_v1/page/summary/{label}", timeout=10
+        )
+        wiki_data = wiki_res.json()
+        wiki_url = wiki_data.get("content_urls", {}).get("desktop", {}).get("page", "")
+    except Exception:
+        pass
+
+    return {"label": label, "is_dangerous": is_dangerous, "wiki_url": wiki_url}

--- a/backend/vision/tests.py
+++ b/backend/vision/tests.py
@@ -1,0 +1,38 @@
+import json
+from django.core.files.uploadedfile import SimpleUploadedFile
+from django_celery_results.models import TaskResult
+from rest_framework.test import APITestCase
+from unittest.mock import patch
+
+
+class VisionIdentifyTest(APITestCase):
+    def _mock_success(self, task_id, payload):
+        TaskResult.objects.update_or_create(
+            task_id=task_id, defaults={"status": "SUCCESS", "result": json.dumps(payload)}
+        )
+
+    def test_identify_kickoff_and_result(self):
+        img = SimpleUploadedFile("t.jpg", b"hi", content_type="image/jpeg")
+        with patch("vision.views.identify_image_task.delay") as mock_delay:
+            mock_delay.return_value.id = "55555555-5555-5555-5555-555555555555"
+            res = self.client.post("/api/vision/identify/", {"file": img})
+        self.assertEqual(res.status_code, 202)
+        tid = res.data["task_id"]
+        self.assertEqual(tid, "55555555-5555-5555-5555-555555555555")
+        payload = {"label": "oak leaf", "is_dangerous": False, "wiki_url": "http://wiki"}
+        self._mock_success(tid, payload)
+        res = self.client.get(f"/api/core/tasks/{tid}/")
+        self.assertEqual(res.status_code, 200)
+        self.assertEqual(res.data["state"], "SUCCESS")
+        self.assertEqual(json.loads(res.data["data"]), payload)
+
+    def test_rate_limit(self):
+        with patch("vision.views.identify_image_task.delay") as mock_delay:
+            mock_delay.return_value.id = "1"
+            for _ in range(10):
+                img = SimpleUploadedFile("t.jpg", b"hi", content_type="image/jpeg")
+                res = self.client.post("/api/vision/identify/", {"file": img})
+                self.assertEqual(res.status_code, 202)
+            img = SimpleUploadedFile("t.jpg", b"hi", content_type="image/jpeg")
+            res = self.client.post("/api/vision/identify/", {"file": img})
+            self.assertEqual(res.status_code, 429)

--- a/backend/vision/urls.py
+++ b/backend/vision/urls.py
@@ -1,0 +1,6 @@
+from django.urls import path
+from .views import identify_image
+
+urlpatterns = [
+    path("identify/", identify_image),
+]

--- a/backend/vision/views.py
+++ b/backend/vision/views.py
@@ -1,0 +1,33 @@
+import os
+import uuid
+from django.conf import settings
+from django.views.decorators.csrf import csrf_exempt
+from ratelimit.decorators import ratelimit
+from rest_framework import status
+from rest_framework.decorators import api_view, permission_classes
+from rest_framework.permissions import AllowAny
+from rest_framework.response import Response
+
+try:
+    from .tasks import identify_image_task
+except Exception:  # pragma: no cover - Celery not loaded
+    identify_image_task = None
+
+
+@csrf_exempt
+@api_view(["POST"])
+@permission_classes([AllowAny])
+@ratelimit(key="ip", rate="10/m", block=True)
+def identify_image(request):
+    file = request.FILES.get("file")
+    if not file:
+        return Response({"error": "file required"}, status=400)
+    filename = f"{uuid.uuid4().hex}_{file.name}"
+    dir_path = os.path.join(settings.MEDIA_ROOT, "vision")
+    os.makedirs(dir_path, exist_ok=True)
+    path = os.path.join(dir_path, filename)
+    with open(path, "wb") as f:
+        for chunk in file.chunks():
+            f.write(chunk)
+    task = identify_image_task.delay(path)
+    return Response({"task_id": task.id}, status=status.HTTP_202_ACCEPTED)

--- a/docs/WHAT_IS_THIS.md
+++ b/docs/WHAT_IS_THIS.md
@@ -1,0 +1,22 @@
+# What Is This? Vision Identification
+
+This feature lets you upload a hiking photo and receive a label and safety warning powered by OpenAI Vision.
+
+## API Usage
+
+```bash
+curl -F "file=@snake.jpg" http://localhost:8000/api/vision/identify/
+```
+Response
+```json
+{"task_id": "<uuid>"}
+```
+Then poll `/api/core/tasks/<uuid>/` until you get:
+```json
+{"state": "SUCCESS", "data": "{\"label\":\"rattlesnake\",\"is_dangerous\":true,\"wiki_url\":\"https://en.wikipedia.org/...\"}"}
+```
+
+## UI
+
+The Today page now has a purple camera button. Choose a photo or take one and you will see a sheet with the name, danger status and a link to Wikipedia.
+

--- a/frontend/momentum_flutter/lib/services/api_service.dart
+++ b/frontend/momentum_flutter/lib/services/api_service.dart
@@ -1,6 +1,7 @@
 import 'dart:convert';
 import 'dart:io';
 import 'package:http/http.dart' as http;
+import 'package:image_picker/image_picker.dart';
 import 'auth_service.dart';
 import '../config.dart';
 
@@ -265,6 +266,16 @@ class ApiService {
 
     final body = await response.stream.bytesToString();
     return json.decode(body) as Map<String, dynamic>;
+  }
+
+  static Future<String> Function(String url, XFile file) uploadImage = _uploadImage;
+
+  static Future<String> _uploadImage(String url, XFile file) async {
+    final req = http.MultipartRequest('POST', Uri.parse(baseUrl + url));
+    req.files.add(await http.MultipartFile.fromPath('file', file.path));
+    final streamed = await req.send();
+    final res = await http.Response.fromStream(streamed);
+    return jsonDecode(res.body)['task_id'] as String;
   }
 
   static Future<void> logout() async {

--- a/frontend/momentum_flutter/lib/services/task_poller.dart
+++ b/frontend/momentum_flutter/lib/services/task_poller.dart
@@ -3,7 +3,10 @@ import 'dart:async';
 import 'api_service.dart';
 
 class TaskPoller {
-  static Future<Map<String, dynamic>> poll(String id,
+  static Future<Map<String, dynamic>> Function(String id,
+      {Duration interval}) poll = _poll;
+
+  static Future<Map<String, dynamic>> _poll(String id,
       {Duration interval = const Duration(seconds: 2)}) async {
     while (true) {
       final res = await ApiService.get('/api/core/tasks/$id/');

--- a/frontend/momentum_flutter/pubspec.yaml
+++ b/frontend/momentum_flutter/pubspec.yaml
@@ -43,6 +43,8 @@ dependencies:
   audioplayers: ^5.2.0
   path_provider: ^2.1.5
   permission_handler: ^12.0.0+1
+  image_picker: ^1.0.7
+  camera: ^0.10.5+9
 
   # The following adds the Cupertino Icons font to your application.
   # Use with the CupertinoIcons class for iOS style icons.

--- a/frontend/momentum_flutter/test/vision_feature_test.dart
+++ b/frontend/momentum_flutter/test/vision_feature_test.dart
@@ -1,0 +1,43 @@
+import 'dart:convert';
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:image_picker/image_picker.dart';
+import 'package:momentum_flutter/pages/today_page.dart';
+import 'package:momentum_flutter/services/task_poller.dart';
+import 'package:momentum_flutter/services/api_service.dart';
+
+void main() {
+  const MethodChannel channel = MethodChannel('plugins.flutter.io/flutter_secure_storage');
+  TestWidgetsFlutterBinding.ensureInitialized();
+  channel.setMockMethodCallHandler((MethodCall methodCall) async {
+    return null;
+  });
+
+  testWidgets('Vision flow shows result sheet', (WidgetTester tester) async {
+    TestWidgetsFlutterBinding.ensureInitialized();
+    final pickerChannel = const MethodChannel('plugins.flutter.io/image_picker');
+    pickerChannel.setMockMethodCallHandler((MethodCall methodCall) async {
+      return '/tmp/test.jpg';
+    });
+
+    TaskPoller.poll = (String id, {Duration interval = const Duration(seconds: 2)}) async {
+      return {
+        'state': 'SUCCESS',
+        'data': jsonEncode({'label':'oak leaf','is_dangerous':false,'wiki_url':'http://wiki'})
+      };
+    };
+
+    ApiService.uploadImage = (String url, XFile file) async => '123';
+
+    await tester.pumpWidget(const MaterialApp(home: TodayPage()));
+    await tester.pump();
+
+    await tester.tap(find.byIcon(Icons.camera_alt));
+    await tester.pumpAndSettle();
+
+    expect(find.text('🏷  Name: oak leaf'), findsOneWidget);
+    expect(find.text('☠️ Dangerous: No'), findsOneWidget);
+    expect(find.text('🔗 Wikipedia'), findsOneWidget);
+  });
+}


### PR DESCRIPTION
## Summary
- add `vision` Django app with endpoint and Celery task
- update settings & URLs to include vision routes
- add Flutter camera FAB and API service upload helper
- allow overriding task poller and uploadImage for tests
- document using the new endpoint and remove screenshot

## Testing
- `pytest -q`
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6854cea0cb18832396044ba2bf3941d9