### PR TITLE
Add voice journal and paged herd feed

### DIFF
--- a/frontend/momentum_flutter/lib/main.dart
+++ b/frontend/momentum_flutter/lib/main.dart
@@ -53,8 +53,12 @@ class MyApp extends StatelessWidget {
           routes: {
             VoiceJournalPage.routeName: (_) => const VoiceJournalPage(),
             ChallengeResultPage.routeName: (context) {
-              final args = ModalRoute.of(context)!.settings.arguments as String;
-              return ChallengeResultPage(challengeText: args);
+              final args = ModalRoute.of(context)!.settings.arguments
+                  as Map<String, dynamic>;
+              return ChallengeResultPage(
+                challengeId: args['id'] as int,
+                challengeText: args['text'] as String,
+              );
             },
           },
         );

--- a/frontend/momentum_flutter/lib/models/feed_item.dart
+++ b/frontend/momentum_flutter/lib/models/feed_item.dart
@@ -1,0 +1,28 @@
+class FeedItem {
+  final int id;
+  final String type;
+  final String imageUrl;
+  final String caption;
+  int likeCount;
+  bool likedByMe;
+
+  FeedItem({
+    required this.id,
+    required this.type,
+    required this.imageUrl,
+    required this.caption,
+    required this.likeCount,
+    required this.likedByMe,
+  });
+
+  factory FeedItem.fromJson(Map<String, dynamic> json) {
+    return FeedItem(
+      id: json['id'] as int,
+      type: json['type'] as String,
+      imageUrl: json['image_url'] as String? ?? '',
+      caption: json['caption'] as String? ?? '',
+      likeCount: json['like_count'] as int? ?? 0,
+      likedByMe: json['liked_by_me'] as bool? ?? false,
+    );
+  }
+}

--- a/frontend/momentum_flutter/lib/models/today_dashboard.dart
+++ b/frontend/momentum_flutter/lib/models/today_dashboard.dart
@@ -1,13 +1,15 @@
 import 'package:flutter/foundation.dart';
 
 class Challenge {
+  final int id;
   final String text;
   final DateTime expiresAt;
 
-  Challenge({required this.text, required this.expiresAt});
+  Challenge({required this.id, required this.text, required this.expiresAt});
 
   factory Challenge.fromJson(Map<String, dynamic> json) {
     return Challenge(
+      id: json['id'] as int,
       text: json['text'] as String,
       expiresAt: DateTime.parse(json['expires_at'] as String),
     );

--- a/frontend/momentum_flutter/lib/pages/herd_feed_page.dart
+++ b/frontend/momentum_flutter/lib/pages/herd_feed_page.dart
@@ -1,30 +1,54 @@
 import 'package:flutter/material.dart';
 import 'package:intl/intl.dart';
+import 'package:infinite_scroll_pagination/infinite_scroll_pagination.dart';
 
-import '../models/herd_post.dart';
+import '../models/feed_item.dart';
 import '../services/api_service.dart';
 import '../themes/app_theme.dart';
 
 class HerdFeedPage extends StatefulWidget {
-  const HerdFeedPage({super.key});
+  const HerdFeedPage({Key? key}) : super(key: key);
 
   @override
   State<HerdFeedPage> createState() => _HerdFeedPageState();
 }
 
 class _HerdFeedPageState extends State<HerdFeedPage> {
-  late Future<List<HerdPost>> _future;
+  final PagingController<int, FeedItem> _pageController =
+      PagingController(firstPageKey: 1);
 
   @override
   void initState() {
     super.initState();
-    _future = ApiService.fetchHerdFeed();
+    _pageController.addPageRequestListener(_fetch);
   }
 
-  Future<void> _refresh() async {
+  Future<void> _fetch(int page) async {
+    try {
+      final items = await ApiService.fetchHerdFeedPage(page);
+      final isLast = items.length < 10;
+      if (isLast) {
+        _pageController.appendLastPage(items);
+      } else {
+        _pageController.appendPage(items, page + 1);
+      }
+    } catch (e) {
+      _pageController.error = e;
+    }
+  }
+
+  Future<void> _toggleLike(FeedItem item) async {
+    final res = await ApiService.toggleLike(item.id);
     setState(() {
-      _future = ApiService.fetchHerdFeed();
+      item.likeCount = res['like_count'] as int? ?? item.likeCount;
+      item.likedByMe = res['liked_by_me'] as bool? ?? item.likedByMe;
     });
+  }
+
+  @override
+  void dispose() {
+    _pageController.dispose();
+    super.dispose();
   }
 
   @override
@@ -32,56 +56,20 @@ class _HerdFeedPageState extends State<HerdFeedPage> {
     return Scaffold(
       appBar: AppBar(title: const Text('Herd Feed 🫏')),
       body: RefreshIndicator(
-        onRefresh: _refresh,
-        child: FutureBuilder<List<HerdPost>>(
-          future: _future,
-          builder: (context, snapshot) {
-            if (snapshot.connectionState == ConnectionState.waiting) {
-              return const Center(child: CircularProgressIndicator());
-            } else if (snapshot.hasError) {
-              return Center(child: Text('Error: ${snapshot.error}'));
-            }
-
-            final posts = snapshot.data!..sort((a, b) => b.createdAt.compareTo(a.createdAt));
-            return ListView.builder(
-              padding: const EdgeInsets.all(16),
-              itemCount: posts!.length,
-              itemBuilder: (context, index) => _buildPostCard(posts[index]),
-            );
-          },
+        onRefresh: () => Future.sync(() => _pageController.refresh()),
+        child: PagedListView<int, FeedItem>(
+          pagingController: _pageController,
+          padding: const EdgeInsets.all(16),
+          builderDelegate: PagedChildBuilderDelegate<FeedItem>(
+            itemBuilder: (context, item, index) => _buildCard(item),
+          ),
         ),
       ),
     );
   }
 
-  Widget _buildPostCard(HerdPost post) {
-    final timestamp = DateFormat.yMMMd().add_jm().format(post.createdAt.toLocal());
-    Widget content;
-    if (post.type == 'meme') {
-      content = Column(
-        crossAxisAlignment: CrossAxisAlignment.start,
-        children: [
-          if (post.content['image_url'] != null)
-            Image.network(post.content['image_url'] as String, fit: BoxFit.cover),
-          const SizedBox(height: 8),
-          Text(post.content['caption'] as String? ?? ''),
-        ],
-      );
-    } else if (post.type == 'badge') {
-      content = Row(
-        children: [
-          Text(
-            post.content['emoji'] as String? ?? '🏅',
-            style: const TextStyle(fontSize: 32, inherit: true),
-          ),
-          const SizedBox(width: 8),
-          Text(post.content['name'] as String? ?? ''),
-        ],
-      );
-    } else {
-      content = const SizedBox.shrink();
-    }
-
+  Widget _buildCard(FeedItem item) {
+    final ts = DateFormat.yMMMd().add_jm().format(DateTime.now());
     return Card(
       color: AppColors.donkeyCard,
       child: Padding(
@@ -91,17 +79,24 @@ class _HerdFeedPageState extends State<HerdFeedPage> {
           children: [
             Row(
               children: [
-                CircleAvatar(
-                  child: Text(post.user.substring(0, 1).toUpperCase()),
-                ),
-                const SizedBox(width: 8),
-                Text(post.user, style: const TextStyle(inherit: true)),
+                Text(ts, style: Theme.of(context).textTheme.bodySmall),
                 const Spacer(),
-                Text(timestamp, style: Theme.of(context).textTheme.bodySmall),
+                IconButton(
+                  icon: Icon(
+                    item.likedByMe ? Icons.favorite : Icons.favorite_border,
+                    color: Colors.red,
+                  ),
+                  onPressed: () => _toggleLike(item),
+                ),
+                Text(item.likeCount.toString()),
               ],
             ),
-            const SizedBox(height: 8),
-            content,
+            if (item.imageUrl.isNotEmpty)
+              Image.network(item.imageUrl, fit: BoxFit.cover),
+            if (item.caption.isNotEmpty) ...[
+              const SizedBox(height: 8),
+              Text(item.caption),
+            ],
           ],
         ),
       ),

--- a/frontend/momentum_flutter/lib/pages/today_page.dart
+++ b/frontend/momentum_flutter/lib/pages/today_page.dart
@@ -357,7 +357,7 @@ class _TodayPageState extends State<TodayPage> {
               onPressed: () async {
                 final result = await Navigator.of(context).pushNamed(
                   ChallengeResultPage.routeName,
-                  arguments: challenge.text,
+                  arguments: {'id': challenge.id, 'text': challenge.text},
                 );
                 if (result == true && mounted) {
                   ScaffoldMessenger.of(context).showSnackBar(

--- a/frontend/momentum_flutter/pubspec.yaml
+++ b/frontend/momentum_flutter/pubspec.yaml
@@ -45,6 +45,7 @@ dependencies:
   permission_handler: ^12.0.0+1
   image_picker: ^1.0.7
   camera: ^0.10.5+9
+  infinite_scroll_pagination: ^3.2.0
 
   # The following adds the Cupertino Icons font to your application.
   # Use with the CupertinoIcons class for iOS style icons.

--- a/frontend/momentum_flutter/test/herd_feed_pagination_test.dart
+++ b/frontend/momentum_flutter/test/herd_feed_pagination_test.dart
@@ -1,0 +1,49 @@
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:momentum_flutter/models/feed_item.dart';
+import 'package:momentum_flutter/pages/herd_feed_page.dart';
+import 'package:momentum_flutter/services/api_service.dart';
+import 'package:infinite_scroll_pagination/infinite_scroll_pagination.dart';
+
+void main() {
+  const MethodChannel channel = MethodChannel('plugins.flutter.io/flutter_secure_storage');
+  TestWidgetsFlutterBinding.ensureInitialized();
+  channel.setMockMethodCallHandler((MethodCall methodCall) async => null);
+
+  testWidgets('Scrolling fetches next page', (tester) async {
+    bool calledPage2 = false;
+    bool likeCalled = false;
+    ApiService.fetchHerdFeedPage = (int page) async {
+      if (page == 1) {
+        return List.generate(
+            10,
+            (i) => FeedItem(
+                id: i,
+                type: 'meme',
+                imageUrl: '',
+                caption: 'c$i',
+                likeCount: 0,
+                likedByMe: false));
+      }
+      calledPage2 = true;
+      return <FeedItem>[];
+    };
+    ApiService.toggleLike = (int id) async {
+      likeCalled = true;
+      return {'like_count': 1, 'liked_by_me': true};
+    };
+
+    await tester.pumpWidget(const MaterialApp(home: HerdFeedPage()));
+    await tester.pumpAndSettle();
+
+    await tester.drag(find.byType(PagedListView<int, FeedItem>), const Offset(0, -1000));
+    await tester.pumpAndSettle();
+
+    await tester.tap(find.byIcon(Icons.favorite_border).first);
+    await tester.pump();
+
+    expect(calledPage2, true);
+    expect(likeCalled, true);
+  });
+}

--- a/frontend/momentum_flutter/test/voice_journal_page_test.dart
+++ b/frontend/momentum_flutter/test/voice_journal_page_test.dart
@@ -1,0 +1,42 @@
+import 'dart:convert';
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:momentum_flutter/pages/voice_journal_page.dart';
+import 'package:momentum_flutter/services/api_service.dart';
+import 'package:momentum_flutter/services/task_poller.dart';
+import 'package:record/record.dart';
+
+class FakeRecord extends Fake implements Record {
+  @override
+  Future<void> start({RecordConfig? config, String? path}) async {}
+
+  @override
+  Future<String?> stop() async => '/tmp/test.m4a';
+}
+
+void main() {
+  const MethodChannel channel = MethodChannel('plugins.flutter.io/flutter_secure_storage');
+  TestWidgetsFlutterBinding.ensureInitialized();
+  channel.setMockMethodCallHandler((MethodCall methodCall) async => null);
+
+  testWidgets('VoiceJournalPage shows result after upload', (tester) async {
+    ApiService.uploadVoice = (String path) async => '1';
+    TaskPoller.poll = (String id, {Duration interval = const Duration(seconds: 2)}) async {
+      return {
+        'state': 'SUCCESS',
+        'data': jsonEncode({'summary': 'hello', 'audio_url': '/a'})
+      };
+    };
+
+    await tester.pumpWidget(MaterialApp(home: VoiceJournalPage(recorder: FakeRecord())));
+    await tester.pump();
+
+    await tester.longPress(find.byIcon(Icons.mic));
+    await tester.pump();
+    await tester.tap(find.byIcon(Icons.stop));
+    await tester.pump();
+
+    expect(find.text('hello'), findsOneWidget);
+  });
+}


### PR DESCRIPTION
## Summary
- implement voice journal recording/upload/polling
- allow completing challenges and sharing badges
- paginate herd feed with likes support
- update models and routes
- add widget tests for voice journal and herd feed

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'django')*
- `flutter test` *(fails: flutter: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6854d71c27548323b097c99aaf0750cb