### PR TITLE
Fix missing FeedItem import

### DIFF
--- a/frontend/momentum_flutter/lib/services/api_service.dart
+++ b/frontend/momentum_flutter/lib/services/api_service.dart
@@ -9,6 +9,7 @@ import '../models/today_dashboard.dart';
 import '../models/badge.dart';
 import '../models/meme.dart';
 import '../models/herd_post.dart';
+import '../models/feed_item.dart';
 import '../models/profile.dart';
 import '../models/daily_goal.dart';
 import 'task_poller.dart';


### PR DESCRIPTION
## Summary
- import `FeedItem` in `ApiService`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_6854d95999148323af716dec55f0e796