### PR TITLE
Fix flutter build by updating plugin

### DIFF
--- a/frontend/momentum_flutter/pubspec.lock
+++ b/frontend/momentum_flutter/pubspec.lock
@@ -396,10 +396,10 @@ packages:
     dependency: "direct main"
     description:
       name: infinite_scroll_pagination
-      sha256: "9517328f4e373f08f57dbb11c5aac5b05554142024d6b60c903f3b73476d52db"
+      sha256: "9b8f95362928a1de835658835194b435c40f2bfc386f6545c1fd706203df0cd4"
       url: "https://pub.dev"
     source: hosted
-    version: "3.2.0"
+    version: "5.1.0"
   intl:
     dependency: "direct main"
     description:

--- a/frontend/momentum_flutter/pubspec.yaml
+++ b/frontend/momentum_flutter/pubspec.yaml
@@ -45,7 +45,7 @@ dependencies:
   permission_handler: ^12.0.0+1
   image_picker: ^1.0.7
   camera: ^0.10.5+9
-  infinite_scroll_pagination: ^3.2.0
+  infinite_scroll_pagination: ^5.1.0
 
   # The following adds the Cupertino Icons font to your application.
   # Use with the CupertinoIcons class for iOS style icons.


### PR DESCRIPTION
## Summary
- bump `infinite_scroll_pagination` to 5.1.0 so Flutter build works with new `TextTheme` API

## Testing
- `make lint` *(fails: missing separator)*
- `flake8 backend/` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6854dc0df6ec8323b296e29edfca5901