### PR TITLE
Wire Celery worker and async health check

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,6 +19,10 @@ jobs:
           python -m venv venv
           . venv/bin/activate
           pip install -r backend/requirements.txt
+      - name: Start Celery worker
+        run: |
+          . venv/bin/activate
+          make run-worker &
       - name: Run tests
         run: |
           . venv/bin/activate

--- a/Makefile
+++ b/Makefile
@@ -28,7 +28,7 @@ shell:
 
 
 run-worker:
-    cd $(BACKEND_DIR) && $(ACTIVATE) && celery -A server worker -l info --concurrency=4
+    cd backend && ../venv/bin/python -m celery -A server worker -l info --concurrency=4
 
 
 lint:

--- a/backend/accounts/tasks.py
+++ b/backend/accounts/tasks.py
@@ -20,7 +20,4 @@ def send_verification_email(user_id: int):
         body=f"Click to verify: {url}",
         to=[user.email],
     )
-    if getattr(settings, "CELERY_DISABLED", "0") == "1":
-        msg.send(fail_silently=True)
-    else:
-        msg.send()
+    msg.send()

--- a/backend/accounts/tests/conftest.py
+++ b/backend/accounts/tests/conftest.py
@@ -5,9 +5,5 @@ import django
 
 def pytest_configure():
     os.environ.setdefault("DJANGO_SETTINGS_MODULE", "server.settings")
-    os.environ.setdefault("CELERY_DISABLED", "1")
     os.environ.setdefault("RUNNING_TESTS", "1")
     django.setup()
-    from django.conf import settings
-
-    settings.CELERY_DISABLED = "1"

--- a/backend/conftest.py
+++ b/backend/conftest.py
@@ -4,9 +4,5 @@ import django
 
 def pytest_configure():
     os.environ.setdefault("DJANGO_SETTINGS_MODULE", "server.settings")
-    os.environ.setdefault("CELERY_DISABLED", "1")
     os.environ.setdefault("RUNNING_TESTS", "1")
     django.setup()
-    from django.conf import settings
-
-    settings.CELERY_DISABLED = "1"

--- a/backend/core/tests_async_endpoints.py
+++ b/backend/core/tests_async_endpoints.py
@@ -79,3 +79,10 @@ class AsyncEndpointsTest(APITestCase):
         tid = res.data["task_id"]
         self.assertEqual(tid, "44444444-4444-4444-4444-444444444444")
         self._check_status(tid, {"voice": "done"})
+
+    def test_celery_ping(self):
+        with patch("core.views.celery_app.control.ping") as mock_ping:
+            mock_ping.return_value = ["pong"]
+            res = self.client.get("/api/core/celery-ping/")
+        self.assertEqual(res.status_code, 200)
+        self.assertEqual(res.data["status"], "ok")

--- a/backend/core/urls.py
+++ b/backend/core/urls.py
@@ -2,10 +2,10 @@ from django.urls import path
 from rest_framework.routers import DefaultRouter
 
 from .views import (CurrentProfileView, PaddleLogViewSet, ProfileViewSet,
-                    TaskStatusView, UserViewSet, create_movement_goal,
-                    daily_goal_view, dashboard_feed, generate_meal_plan_view,
-                    generate_workout_plan, get_mood_avatar_view, log_workout,
-                    update_mood)
+                    TaskStatusView, UserViewSet, celery_ping,
+                    create_movement_goal, daily_goal_view, dashboard_feed,
+                    generate_meal_plan_view, generate_workout_plan,
+                    get_mood_avatar_view, log_workout, update_mood)
 
 router = DefaultRouter()
 router.register(r"users", UserViewSet)
@@ -24,4 +24,5 @@ urlpatterns = router.urls + [
     path("log-workout/", log_workout),
     path("meal-plan/", generate_meal_plan_view),
     path("tasks/<uuid:task_id>/", TaskStatusView.as_view()),
+    path("celery-ping/", celery_ping),
 ]

--- a/docs/ASYNC_AI.md
+++ b/docs/ASYNC_AI.md
@@ -8,6 +8,15 @@ source .venv/bin/activate
 celery -A server worker -l info --concurrency=4
 ```
 
+The worker uses the `REDIS_URL` environment variable for its broker.
+After it starts you can verify the connection with:
+
+```bash
+celery -A server inspect ping
+```
+
+You should see a `pong` response which confirms the worker is talking to Redis.
+
 API clients should POST to the kick-off endpoints which return a `task_id` and `202` status:
 
 - `POST /api/content/meme/`


### PR DESCRIPTION
## Summary
- document verifying Celery worker connects to Redis
- remove CELERY_DISABLED fallbacks
- add Celery ping endpoint and tests
- ensure worker can be started via Makefile
- start Celery worker in CI

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6854e3303c14832381188203855e252e