### PR TITLE
Add voice journal & movement challenge tests

### DIFF
--- a/backend/movement/tests.py
+++ b/backend/movement/tests.py
@@ -6,11 +6,15 @@ from rest_framework.test import APITestCase
 import unittest
 
 
-@unittest.skip("legacy tests")
 class MovementAPITest(APITestCase):
     def setUp(self):
-        self.user = User.objects.create_user(email="mover@example.com", password="pass")
-        self.client.login(email="mover@example.com", password="pass")
+        self.user = User.objects.create_user(
+            username="mover", email="mover@example.com", password="pass", is_verified=True
+        )
+        from rest_framework_simplejwt.tokens import RefreshToken
+
+        refresh = RefreshToken.for_user(self.user)
+        self.client.credentials(HTTP_AUTHORIZATION=f"Bearer {refresh.access_token}")
 
     def test_create_challenge_and_session(self):
         chal_resp = self.client.post(

--- a/backend/voice_journals/tests/test_upload_flow.py
+++ b/backend/voice_journals/tests/test_upload_flow.py
@@ -1,0 +1,62 @@
+import pytest
+from django.contrib.auth import get_user_model
+from django.core.files.uploadedfile import SimpleUploadedFile
+from rest_framework.test import APIClient
+from rest_framework_simplejwt.tokens import RefreshToken
+
+from voice_journals.models import VoiceJournal
+
+
+@pytest.mark.django_db
+def test_upload_and_process_voice_journal(monkeypatch):
+    User = get_user_model()
+    user = User.objects.create_user(
+        username="vj", email="vj@example.com", password="pass", is_verified=True
+    )
+    client = APIClient()
+    refresh = RefreshToken.for_user(user)
+    client.credentials(HTTP_AUTHORIZATION=f"Bearer {refresh.access_token}")
+
+    audio = SimpleUploadedFile("voice.wav", b"audio")
+
+    captured = {}
+
+    def fake_delay(jid):
+        captured["jid"] = jid
+        class R:
+            id = "task123"
+        return R()
+
+    monkeypatch.setattr(
+        "voice_journals.views.process_voice_journal_task.delay", fake_delay
+    )
+
+    res = client.post("/api/voice/transcribe/", {"audio_file": audio})
+    assert res.status_code == 202
+
+    journal = VoiceJournal.objects.get()
+    assert captured["jid"] == journal.id
+
+    monkeypatch.setattr(
+        "voice_journals.utils.voice_helpers.transcribe_audio", lambda path: "hello world"
+    )
+    monkeypatch.setattr(
+        "voice_journals.utils.voice_helpers.summarize_text", lambda text: "summary"
+    )
+    monkeypatch.setattr(
+        "voice_journals.utils.voice_helpers.generate_tags_from_text", lambda text: ["tag1"]
+    )
+    monkeypatch.setattr(
+        "voice_journals.utils.tts_helpers.text_to_speech", lambda text, path: path
+    )
+
+    from voice_journals.tasks import process_voice_journal_task
+
+    result = process_voice_journal_task(journal.id)
+
+    journal.refresh_from_db()
+    assert journal.transcript == "hello world"
+    assert journal.summary == "summary"
+    assert journal.tags == ["tag1"]
+    assert journal.playback_audio_url
+    assert result["id"] == journal.id


### PR DESCRIPTION
## Summary
- add VoiceJournal upload and processing test
- enable MovementChallenge API test

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6854e820ba708323906952d55bf218a4