### PR TITLE
Fix CI workflow commands

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,11 +23,21 @@ jobs:
         run: |
           . venv/bin/activate
           make run-worker &
-      - name: Run tests
+      - name: Run backend tests
         run: |
           . venv/bin/activate
-          make test-backend
-      - name: Lint
+          pytest
+      - name: Lint backend
         run: |
           . venv/bin/activate
-          make lint-backend
+          flake8 backend
+      - name: Set up Flutter
+        uses: subosito/flutter-action@v2
+      - name: Install Flutter dependencies
+        run: |
+          cd frontend/momentum_flutter
+          flutter pub get
+      - name: Run Flutter tests
+        run: |
+          cd frontend/momentum_flutter
+          flutter test

--- a/Makefile
+++ b/Makefile
@@ -1,11 +1,9 @@
-# Makefile for MoveThatAss project
+# Makefile for MoveYourAzz project
 
-# Python & Django settings
 PYTHON := python3
 MANAGE := $(PYTHON) backend/manage.py
 
-# Targets
-.PHONY: run migrate makemigrations superuser shell test lint clean reset flutter_run
+.PHONY: run migrate makemigrations superuser shell run-worker test-backend lint-backend clean reset flutter_run
 
 run:
 	@echo "Starting Django development server..."
@@ -26,13 +24,15 @@ superuser:
 shell:
 	$(MANAGE) shell
 
-
 run-worker:
-    cd backend && ../venv/bin/python -m celery -A server worker -l info --concurrency=4
+	cd backend && ../venv/bin/python -m celery -A server worker -l info --concurrency=4
 
+test-backend:
+	@echo "Running backend tests..."
+	pytest
 
-lint:
-	@echo "Linting Python code..."
+lint-backend:
+	@echo "Linting backend..."
 	flake8 backend/
 
 clean:
@@ -47,4 +47,4 @@ reset:
 
 flutter_run:
 	@echo "Starting Flutter app..."
-	cd frontend && cd momentum_flutter && flutter run --no-publish-port
+	cd frontend/momentum_flutter && flutter run --no-publish-port


### PR DESCRIPTION
## Summary
- correct CI commands to call pytest and flake8
- add Flutter test execution using flutter-action
- add `test-backend` and `lint-backend` targets in Makefile

## Testing
- `pytest`
- `flake8 backend` *(fails: command not found once venv removed)*

------
https://chatgpt.com/codex/tasks/task_e_6854e9cda93083239e7645138ffc55e2