### PR TITLE
Upgrade Celery, JWT, OpenAI versions

### DIFF
--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -10,7 +10,7 @@ httpcore==1.0.9
 httpx==0.28.1
 idna==3.10
 jiter==0.10.0
-openai==1.86.0
+openai==1.88.0
 psycopg==3.2.9
 pydantic==2.11.7
 pydantic_core==2.33.2
@@ -22,11 +22,11 @@ typing_extensions==4.14.0
 python-dotenv==1.0.1
 requests==2.32.3
 
-celery[redis]==5.3.6
+celery[redis]==5.5.3
 django-celery-results==2.6.0
 redis==5.0.4
 dj-database-url==3.0.0
-djangorestframework-simplejwt==5.3.1
+djangorestframework-simplejwt==5.5.0
 django-cors-headers==4.3.1
 pytest==8.2.2
 pytest-django==4.8.0


### PR DESCRIPTION
## Summary
- update Celery to 5.5.3
- update djangorestframework-simplejwt to 5.5.0
- update OpenAI to 1.88.0

## Testing
- `backend/.venv/bin/pytest -q`
- `SECRET_KEY=dummy REDIS_URL=redis://localhost:6379/0 ../backend/.venv/bin/celery -A server worker --loglevel INFO -c 1 --pool solo` (fails to connect to Redis after start)

------
https://chatgpt.com/codex/tasks/task_e_6854eb1d58dc8323817b7f9b5de57cac