### PR TITLE
Fix deprecated allauth settings

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,0 +1,3 @@
+[flake8]
+max-line-length = 88
+exclude = .venv,venv,env,backend/.venv,**/migrations/*,build,dist

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -128,6 +128,10 @@ Codex should:
 - `.venv/` and `db.sqlite3` must never be committed
 - `AZZ_MODE` env var may be used to toggle between safe/roast modes
 - Feature flag support (badges, voice journal, herds) is encouraged
+- Do **not** reintroduce deprecated allauth settings like
+  `ACCOUNT_AUTHENTICATION_METHOD`, `ACCOUNT_EMAIL_REQUIRED`, or
+  `ACCOUNT_USERNAME_REQUIRED`. The project uses `ACCOUNT_SIGNUP_FIELDS`
+  and `ACCOUNT_LOGIN_METHODS` instead.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -52,3 +52,10 @@ curl -X POST http://127.0.0.1:8000/api/auth/registration/ \
    -H 'Content-Type: application/json' \
    -d '{"email":"alice@mail.com","password1":"Pass123!","password2":"Pass123!"}'
 ```
+
+### ⚠️ Do Not Reintroduce Deprecated Auth Settings
+
+The backend uses the latest `django-allauth` configuration. Avoid adding
+`ACCOUNT_AUTHENTICATION_METHOD`, `ACCOUNT_EMAIL_REQUIRED`, or
+`ACCOUNT_USERNAME_REQUIRED` back into `server/settings.py`. Those options are
+deprecated and will trigger runtime warnings.

--- a/backend/server/settings.py
+++ b/backend/server/settings.py
@@ -66,6 +66,12 @@ INSTALLED_APPS = [
     "django_celery_results",
 ]
 
+# Support email-based login with django-allauth
+AUTHENTICATION_BACKENDS = [
+    "django.contrib.auth.backends.ModelBackend",
+    "allauth.account.auth_backends.AuthenticationBackend",
+]
+
 MIDDLEWARE = [
     "django.middleware.security.SecurityMiddleware",
     "whitenoise.middleware.WhiteNoiseMiddleware",
@@ -142,11 +148,15 @@ SIMPLE_JWT = {
 
 CORS_ALLOW_ALL_ORIGINS = True
 
-ACCOUNT_USERNAME_REQUIRED = False
-ACCOUNT_AUTHENTICATION_METHOD = "email"
+# Configure django-allauth for email based login.
+# Deprecated settings previously caused runtime warnings.
 ACCOUNT_USER_MODEL_USERNAME_FIELD = "username"
-ACCOUNT_EMAIL_REQUIRED = True
-ACCOUNT_SIGNUP_FIELDS = ["email", "password1", "password2"]
+ACCOUNT_SIGNUP_FIELDS = {
+    "email": {"required": True},
+    "password1": {"required": True},
+    "password2": {"required": True},
+    "username": {"required": False},
+}
 ACCOUNT_LOGIN_METHODS = {"email"}
 SITE_ID = 1
 REST_USE_JWT = True

--- a/backend/vision/tests.py
+++ b/backend/vision/tests.py
@@ -2,10 +2,24 @@ import json
 from django.core.files.uploadedfile import SimpleUploadedFile
 from django_celery_results.models import TaskResult
 from rest_framework.test import APITestCase
+from rest_framework_simplejwt.tokens import RefreshToken
+from django.contrib.auth import get_user_model
 from unittest.mock import patch
 
 
+User = get_user_model()
+
+
 class VisionIdentifyTest(APITestCase):
+    def setUp(self):
+        self.user = User.objects.create_user(
+            username="visionuser",
+            email="vision@example.com",
+            password="pass",
+            is_verified=True,
+        )
+        refresh = RefreshToken.for_user(self.user)
+        self.client.credentials(HTTP_AUTHORIZATION=f"Bearer {refresh.access_token}")
     def _mock_success(self, task_id, payload):
         TaskResult.objects.update_or_create(
             task_id=task_id, defaults={"status": "SUCCESS", "result": json.dumps(payload)}


### PR DESCRIPTION
## Summary
- configure django-allauth login using `ACCOUNT_SIGNUP_FIELDS` and `ACCOUNT_LOGIN_METHODS`
- add `AUTHENTICATION_BACKENDS` for email login
- authenticate VisionIdentifyTest
- document not to reintroduce deprecated settings
- add flake8 config to ignore virtualenv

## Testing
- `make lint-backend` *(fails: many style violations)*
- `RUNNING_TESTS=1 pytest -q` *(fails: vision rate-limit test fails)*

------
https://chatgpt.com/codex/tasks/task_e_6854f4f68250832380d2426e5bccffc8