### PR TITLE
Handle missing Celery tasks

### DIFF
--- a/backend/content/api_tests/test_celery_unavailable.py
+++ b/backend/content/api_tests/test_celery_unavailable.py
@@ -1,0 +1,23 @@
+import pytest
+from django.contrib.auth import get_user_model
+from rest_framework.test import APIClient
+from rest_framework import status
+from rest_framework_simplejwt.tokens import RefreshToken
+
+
+@pytest.mark.django_db
+def test_generate_meme_returns_503_when_celery_unavailable(monkeypatch):
+    User = get_user_model()
+    user = User.objects.create_user(
+        username="memer", email="memer@example.com", password="pass", is_verified=True
+    )
+    client = APIClient()
+    refresh = RefreshToken.for_user(user)
+    client.credentials(HTTP_AUTHORIZATION=f"Bearer {refresh.access_token}")
+
+    monkeypatch.setattr("content.views.generate_meme_task", None)
+
+    res = client.post("/api/content/meme/", {"tone": "funny"}, format="json")
+
+    assert res.status_code == status.HTTP_503_SERVICE_UNAVAILABLE
+    assert res.data["detail"] == "Celery worker unavailable"

--- a/backend/content/views.py
+++ b/backend/content/views.py
@@ -1,4 +1,4 @@
-from rest_framework import viewsets
+from rest_framework import status, viewsets
 from rest_framework.decorators import api_view, permission_classes
 from rest_framework.permissions import AllowAny, IsAuthenticated
 from rest_framework.response import Response
@@ -46,5 +46,10 @@ def generate_meme(request):
     """Kick off meme generation via Celery."""
 
     tone = request.data.get("tone", "funny")
+    if generate_meme_task is None:
+        return Response(
+            {"detail": "Celery worker unavailable"},
+            status=status.HTTP_503_SERVICE_UNAVAILABLE,
+        )
     task = generate_meme_task.delay(tone)
     return Response({"task_id": task.id}, status=202)

--- a/backend/voice_journals/tests/test_celery_unavailable.py
+++ b/backend/voice_journals/tests/test_celery_unavailable.py
@@ -1,0 +1,26 @@
+import pytest
+from django.contrib.auth import get_user_model
+from django.core.files.uploadedfile import SimpleUploadedFile
+from rest_framework.test import APIClient
+from rest_framework import status
+from rest_framework_simplejwt.tokens import RefreshToken
+
+
+@pytest.mark.django_db
+def test_voice_transcribe_returns_503_when_celery_unavailable(monkeypatch):
+    User = get_user_model()
+    user = User.objects.create_user(
+        username="vj", email="vj@example.com", password="pass", is_verified=True
+    )
+    client = APIClient()
+    refresh = RefreshToken.for_user(user)
+    client.credentials(HTTP_AUTHORIZATION=f"Bearer {refresh.access_token}")
+
+    audio = SimpleUploadedFile("voice.wav", b"audio")
+
+    monkeypatch.setattr("voice_journals.views.process_voice_journal_task", None)
+
+    res = client.post("/api/voice/transcribe/", {"audio_file": audio})
+
+    assert res.status_code == status.HTTP_503_SERVICE_UNAVAILABLE
+    assert res.data["detail"] == "Celery worker unavailable"

--- a/backend/voice_journals/views.py
+++ b/backend/voice_journals/views.py
@@ -23,5 +23,10 @@ def transcribe_voice(request):
         return Response({"error": "audio_file is required"}, status=400)
 
     journal = VoiceJournal.objects.create(user=request.user, audio_file=audio_file)
+    if process_voice_journal_task is None:
+        return Response(
+            {"detail": "Celery worker unavailable"},
+            status=status.HTTP_503_SERVICE_UNAVAILABLE,
+        )
     task = process_voice_journal_task.delay(journal.id)
     return Response({"task_id": task.id}, status=status.HTTP_202_ACCEPTED)


### PR DESCRIPTION
## Summary
- return 503 from `generate_meme` if Celery isn't loaded
- return 503 from `transcribe_voice` if Celery isn't loaded
- test unavailable Celery worker for meme generation
- test unavailable Celery worker for voice transcription
- move content API tests into their own package

## Testing
- `pytest -q` *(fails: accounts/tests/test_auth_flow.py::FullAuthFlowTest::test_register_login_profile_logout, vision/tests.py::VisionIdentifyTest::test_identify_kickoff_and_result, vision/tests.py::VisionIdentifyTest::test_rate_limit)*

------
https://chatgpt.com/codex/tasks/task_e_6854f577cf848323bbc745b01d04f503