### PR TITLE
Switch auth to username

### DIFF
--- a/backend/accounts/serializers.py
+++ b/backend/accounts/serializers.py
@@ -20,18 +20,10 @@ class ProfileSerializer(serializers.ModelSerializer):
 
 
 
-from allauth.utils import generate_unique_username
-
-
 class CustomRegisterSerializer(BaseRegisterSerializer):
-    """Generate a username automatically from the email."""
+    """Serializer requiring username, email, and passwords."""
 
-    username = None
-
-    def get_cleaned_data(self):
-        data = super().get_cleaned_data()
-        email = data.get("email")
-        data["username"] = generate_unique_username([email]) if email else "user"
-        return data
+    # No overrides needed; BaseRegisterSerializer already handles validation
+    pass
 
 

--- a/backend/accounts/tests/test_auth_flow.py
+++ b/backend/accounts/tests/test_auth_flow.py
@@ -6,6 +6,7 @@ class FullAuthFlowTest(APITestCase):
         res = self.client.post(
             "/api/auth/registration/",
             {
+                "username": "flow",
                 "email": "flow@example.com",
                 "password1": "SuperSecret123",
                 "password2": "SuperSecret123",
@@ -16,7 +17,7 @@ class FullAuthFlowTest(APITestCase):
 
         res = self.client.post(
             "/api/auth/login/",
-            {"email": "flow@example.com", "password": "SuperSecret123"},
+            {"username": "flow", "password": "SuperSecret123"},
             format="json",
         )
         self.assertEqual(res.status_code, 200)

--- a/backend/accounts/tests/test_throttling.py
+++ b/backend/accounts/tests/test_throttling.py
@@ -18,13 +18,13 @@ class AuthThrottleTest(APITestCase):
         for _ in range(3):
             res = self.client.post(
                 "/api/auth/login/",
-                {"email": "ratelimit@example.com", "password": "wrong"},
+                {"username": "ratelimit", "password": "wrong"},
                 format="json",
             )
             self.assertEqual(res.status_code, 400)
         res = self.client.post(
             "/api/auth/login/",
-            {"email": "ratelimit@example.com", "password": "wrong"},
+            {"username": "ratelimit", "password": "wrong"},
             format="json",
         )
         self.assertEqual(res.status_code, 429)
@@ -35,6 +35,7 @@ class AuthThrottleTest(APITestCase):
             res = self.client.post(
                 "/api/auth/registration/",
                 {
+                    "username": f"rl{i}",
                     "email": f"rl{i}@example.com",
                     "password1": "StrongPass123",
                     "password2": "StrongPass123",
@@ -45,6 +46,7 @@ class AuthThrottleTest(APITestCase):
         res = self.client.post(
             "/api/auth/registration/",
             {
+                "username": "rl4",
                 "email": "rl4@example.com",
                 "password1": "StrongPass123",
                 "password2": "StrongPass123",

--- a/backend/server/settings.py
+++ b/backend/server/settings.py
@@ -159,7 +159,7 @@ SIMPLE_JWT = {
 
 CORS_ALLOW_ALL_ORIGINS = True
 
-# Configure django-allauth for email based login.
+# Configure django-allauth for username based login.
 # Deprecated settings previously caused runtime warnings.
 ACCOUNT_USER_MODEL_USERNAME_FIELD = "username"
 ACCOUNT_SIGNUP_FIELDS = [
@@ -168,7 +168,7 @@ ACCOUNT_SIGNUP_FIELDS = [
     "password2*",
     "username",
 ]
-ACCOUNT_LOGIN_METHODS = ["email"]
+ACCOUNT_LOGIN_METHODS = ["username"]
 SITE_ID = 1
 REST_USE_JWT = True
 REST_AUTH = {

--- a/backend/vision/tests.py
+++ b/backend/vision/tests.py
@@ -2,6 +2,7 @@ import json
 from django.core.files.uploadedfile import SimpleUploadedFile
 from django_celery_results.models import TaskResult
 from rest_framework.test import APITestCase
+from django.core.cache import cache
 from rest_framework_simplejwt.tokens import RefreshToken
 from django.contrib.auth import get_user_model
 from unittest.mock import patch
@@ -12,6 +13,7 @@ User = get_user_model()
 
 class VisionIdentifyTest(APITestCase):
     def setUp(self):
+        cache.clear()
         self.user = User.objects.create_user(
             username="visionuser",
             email="vision@example.com",

--- a/frontend/momentum_flutter/lib/pages/login_page.dart
+++ b/frontend/momentum_flutter/lib/pages/login_page.dart
@@ -13,7 +13,7 @@ class LoginPage extends StatefulWidget {
 
 class _LoginPageState extends State<LoginPage> {
   final GlobalKey<FormState> _loginFormKey = GlobalKey<FormState>();
-  final _emailController = TextEditingController();
+  final _usernameController = TextEditingController();
   final _passwordController = TextEditingController();
   String? _error;
   bool _loading = false;
@@ -25,7 +25,7 @@ class _LoginPageState extends State<LoginPage> {
     });
     try {
       await AuthService.login(
-        _emailController.text.trim(),
+        _usernameController.text.trim(),
         _passwordController.text,
       );
       if (!mounted) return;
@@ -41,7 +41,7 @@ class _LoginPageState extends State<LoginPage> {
 
   @override
   void dispose() {
-    _emailController.dispose();
+    _usernameController.dispose();
     _passwordController.dispose();
     super.dispose();
   }
@@ -58,8 +58,8 @@ class _LoginPageState extends State<LoginPage> {
             mainAxisAlignment: MainAxisAlignment.center,
             children: [
             TextField(
-              controller: _emailController,
-              decoration: const InputDecoration(labelText: 'Email'),
+              controller: _usernameController,
+              decoration: const InputDecoration(labelText: 'Username'),
             ),
             const SizedBox(height: 12),
             TextField(

--- a/frontend/momentum_flutter/lib/pages/register_page.dart
+++ b/frontend/momentum_flutter/lib/pages/register_page.dart
@@ -12,6 +12,7 @@ class RegisterPage extends StatefulWidget {
 }
 
 class _RegisterPageState extends State<RegisterPage> {
+  final _usernameController = TextEditingController();
   final _emailController = TextEditingController();
   final _password1Controller = TextEditingController();
   final _password2Controller = TextEditingController();
@@ -25,6 +26,7 @@ class _RegisterPageState extends State<RegisterPage> {
     });
     try {
       await AuthService.register(
+        _usernameController.text.trim(),
         _emailController.text.trim(),
         _password1Controller.text,
         _password2Controller.text,
@@ -49,6 +51,7 @@ class _RegisterPageState extends State<RegisterPage> {
 
   @override
   void dispose() {
+    _usernameController.dispose();
     _emailController.dispose();
     _password1Controller.dispose();
     _password2Controller.dispose();
@@ -64,6 +67,11 @@ class _RegisterPageState extends State<RegisterPage> {
         child: Column(
           mainAxisAlignment: MainAxisAlignment.center,
           children: [
+            TextField(
+              controller: _usernameController,
+              decoration: const InputDecoration(labelText: 'Username'),
+            ),
+            const SizedBox(height: 12),
             TextField(
               controller: _emailController,
               decoration: const InputDecoration(labelText: 'Email'),

--- a/frontend/momentum_flutter/lib/services/auth_service.dart
+++ b/frontend/momentum_flutter/lib/services/auth_service.dart
@@ -14,11 +14,11 @@ class AuthService {
 
   static String get _baseUrl => AppConfig.baseUrl;
 
-  static Future<void> login(String email, String password) async {
+  static Future<void> login(String username, String password) async {
     final response = await client.post(
       Uri.parse('$_baseUrl/api/auth/login/'),
       headers: {'Content-Type': 'application/json'},
-      body: jsonEncode({'email': email, 'password': password}),
+      body: jsonEncode({'username': username, 'password': password}),
     );
     if (response.statusCode != 200) {
       throw Exception('Login failed');
@@ -33,11 +33,13 @@ class AuthService {
     await _storage.write(key: _refreshKey, value: _refresh);
   }
 
-  static Future<bool> register(String email, String p1, String p2) async {
+  static Future<bool> register(
+      String username, String email, String p1, String p2) async {
     final response = await client.post(
       Uri.parse('$_baseUrl/api/auth/registration/'),
       headers: {'Content-Type': 'application/json'},
       body: jsonEncode({
+        'username': username,
         'email': email,
         'password1': p1,
         'password2': p2,


### PR DESCRIPTION
## Summary
- require username when registering
- send username for login
- show username field in RegisterPage
- show username field in LoginPage
- update tests for username-based auth
- clear caches in vision tests

## Testing
- `make test-backend`

------
https://chatgpt.com/codex/tasks/task_e_6854fe7828a483239583736c719f7abb