### PR TITLE
Enable backend pytest execution

### DIFF
--- a/backend/content/tests.py
+++ b/backend/content/tests.py
@@ -1,18 +1,20 @@
 from django.contrib.auth import get_user_model
+from rest_framework.test import APITestCase
+from rest_framework_simplejwt.tokens import RefreshToken
+from unittest.mock import patch
 
 User = get_user_model()
-from rest_framework.test import APITestCase
-from unittest.mock import patch
-import unittest
 
 from .models import GeneratedMeme
 
 
-@unittest.skip("legacy tests")
 class ContentAPITest(APITestCase):
     def setUp(self):
-        self.user = User.objects.create_user(email="connie@example.com", password="pass")
-        self.client.login(email="connie@example.com", password="pass")
+        self.user = User.objects.create_user(
+            username="connie", email="connie@example.com", password="pass"
+        )
+        refresh = RefreshToken.for_user(self.user)
+        self.client.credentials(HTTP_AUTHORIZATION=f"Bearer {refresh.access_token}")
 
     def test_generate_prompt_caption(self):
         with patch("content.views.generate_caption") as mock_cap:
@@ -27,15 +29,11 @@ class ContentAPITest(APITestCase):
         self.assertEqual(resp.data["caption"], "so funny")
 
     def test_generate_meme(self):
-        with patch("content.views.generate_meme_task", None), patch(
-            "content.views.fetch_donkey_gif"
-        ) as gif_mock, patch("content.views.generate_meme_caption") as caption_mock:
-            gif_mock.return_value = "http://gif"
-            caption_mock.return_value = "roast"
-            resp = self.client.post("/api/content/generate-meme/", {}, format="json")
+        class Dummy:
+            id = "task123"
 
-        self.assertEqual(resp.status_code, 200)
-        self.assertEqual(resp.data["image_url"], "http://gif")
-        self.assertEqual(resp.data["caption"], "roast")
-        self.assertEqual(GeneratedMeme.objects.count(), 1)
+        with patch("content.views.generate_meme_task.delay", return_value=Dummy()):
+            resp = self.client.post("/api/content/meme/", {}, format="json")
+        self.assertEqual(resp.status_code, 202)
+        self.assertEqual(resp.data["task_id"], "task123")
 

--- a/backend/core/views.py
+++ b/backend/core/views.py
@@ -3,7 +3,7 @@ from rest_framework import generics, viewsets
 
 User = get_user_model()
 import uuid
-from datetime import datetime, time, timedelta
+from datetime import datetime, time, timedelta, timezone as dt_timezone
 
 from django.shortcuts import get_object_or_404
 from django.utils import timezone
@@ -142,7 +142,7 @@ def dashboard_feed(request):
     if not type_filter or type_filter == "shame":
         for post in apply_filters(ShamePost.objects.all()):
             dt = datetime.combine(post.date, time.min)
-            dt = timezone.make_aware(dt, timezone.utc) if timezone.is_naive(dt) else dt
+            dt = timezone.make_aware(dt, dt_timezone.utc) if timezone.is_naive(dt) else dt
             item = {
                 "type": "shame",
                 "created_at": dt,

--- a/backend/movement/tests.py
+++ b/backend/movement/tests.py
@@ -3,7 +3,6 @@ from django.contrib.auth import get_user_model
 User = get_user_model()
 from django.utils import timezone
 from rest_framework.test import APITestCase
-import unittest
 
 
 class MovementAPITest(APITestCase):

--- a/backend/prompts/tests.py
+++ b/backend/prompts/tests.py
@@ -1,15 +1,17 @@
 from django.contrib.auth import get_user_model
+from rest_framework.test import APITestCase
+from rest_framework_simplejwt.tokens import RefreshToken
 
 User = get_user_model()
-from rest_framework.test import APITestCase
-import unittest
 
 
-@unittest.skip("legacy tests")
 class PromptsAPITest(APITestCase):
     def setUp(self):
-        self.user = User.objects.create_user(email="pro@example.com", password="pass")
-        self.client.login(email="pro@example.com", password="pass")
+        self.user = User.objects.create_user(
+            username="pro", email="pro@example.com", password="pass"
+        )
+        refresh = RefreshToken.for_user(self.user)
+        self.client.credentials(HTTP_AUTHORIZATION=f"Bearer {refresh.access_token}")
 
     def test_prompt_and_response(self):
         p_resp = self.client.post(

--- a/backend/vision/tests.py
+++ b/backend/vision/tests.py
@@ -5,6 +5,7 @@ from rest_framework.test import APITestCase
 from rest_framework_simplejwt.tokens import RefreshToken
 from django.contrib.auth import get_user_model
 from unittest.mock import patch
+from django.core.cache import cache
 
 
 User = get_user_model()
@@ -12,6 +13,7 @@ User = get_user_model()
 
 class VisionIdentifyTest(APITestCase):
     def setUp(self):
+        cache.clear()
         self.user = User.objects.create_user(
             username="visionuser",
             email="vision@example.com",


### PR DESCRIPTION
## Summary
- ensure pytest config points to test settings
- add in-memory DB settings for tests
- activate JWT auth in backend tests and remove skips
- fix test utilities for content, core, vision
- update Makefile test-backend target

## Testing
- `make test-backend`

------
https://chatgpt.com/codex/tasks/task_e_6854fe8799648323acd83e27117e71ca