### PR TITLE
Update frontend test target to check for flutter command

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -43,11 +43,11 @@ test-backend:
 
 test-frontend:
 	cd $(FRONTEND_DIR) && \
-	if [ -n "$$FLUTTER_ROOT" ]; then \
+	if command -v flutter >/dev/null 2>&1; then \
 	flutter test --machine --platform=vm; \
 	else \
 	echo "Skipping flutter tests – SDK not available"; \
-fi
+	fi
 
 lint-backend:
 	@echo "Linting backend..."

--- a/README.md
+++ b/README.md
@@ -62,5 +62,6 @@ Backend tests run with `make test-backend`.
 
 Flutter widget tests run headlessly. Use `make test-frontend`, which invokes
 `flutter test --machine --platform=vm` so no emulator or physical device is
-required.
+required. If the Flutter SDK isn't installed, the Makefile will skip the tests
+and print a message instead.
 


### PR DESCRIPTION
## Summary
- skip Flutter frontend tests when Flutter isn't installed
- document the fallback behavior in README

## Testing
- `make test-backend` *(fails: VisionIdentifyTest::test_rate_limit)*
- `make test-frontend`

------
https://chatgpt.com/codex/tasks/task_e_6854fea5bac883238cac5b47c7ff413f