### PR TITLE
Fix unmatched brace in TodayPage

### DIFF
--- a/frontend/momentum_flutter/lib/pages/today_page.dart
+++ b/frontend/momentum_flutter/lib/pages/today_page.dart
@@ -327,8 +327,7 @@ class _TodayPageState extends State<TodayPage> {
     );
   }
 
-}
-
+  // Build a card for an individual dashboard item
   Widget _buildItem(DashboardItem item) {
     Widget content;
     switch (item.type) {


### PR DESCRIPTION
## Summary
- remove stray closing brace so `_buildItem` remains inside `_TodayPageState`

## Testing
- `make test-backend`
- `make test-frontend` *(fails: Skipping flutter tests – SDK not available)*

------
https://chatgpt.com/codex/tasks/task_e_68558fc4466c8323b25d07f7bc7ba181