### PR TITLE
Production docker setup and security hardening

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -1,0 +1,21 @@
+name: Docker build
+
+on:
+  push:
+    branches: ["*"]
+  pull_request:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Build images
+        run: docker compose -f docker-compose.prod.yml build --no-cache
+      - name: Smoke test redirect
+        run: |
+          docker compose -f docker-compose.prod.yml up -d
+          sleep 10
+          code=$(curl -s -o /dev/null -w "%{http_code}" http://localhost)
+          docker compose -f docker-compose.prod.yml down
+          test "$code" = "301"

--- a/README.md
+++ b/README.md
@@ -1,7 +1,9 @@
 # MoveYourAzz Development
 
-![CI](https://github.com/OWNER/REPO/actions/workflows/ci.yml/badge.svg)
-
+| Status | Badge |
+|-------|-------|
+| CI | ![CI](https://github.com/OWNER/REPO/actions/workflows/ci.yml/badge.svg) |
+| Docker build | ![Docker build](https://github.com/OWNER/REPO/actions/workflows/docker-build.yml/badge.svg) |
 
 This repo contains the Django backend and Flutter frontend projects.
 

--- a/backend/.env.sample
+++ b/backend/.env.sample
@@ -9,3 +9,4 @@ GIPHY_API_KEY=
 REDIS_URL=redis://localhost:6379/0
 DATABASE_URL=
 FRONTEND_BASE_URL=http://localhost:8080
+ALLOWED_ORIGINS=http://localhost:3000,https://moveyourazz.com

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -1,0 +1,8 @@
+FROM python:3.12-slim
+ENV PYTHONDONTWRITEBYTECODE 1
+ENV PYTHONUNBUFFERED 1
+WORKDIR /app
+COPY requirements.txt ./
+RUN pip install --no-cache-dir -r requirements.txt
+COPY . .
+CMD ["gunicorn", "server.wsgi:application", "-b", "0.0.0.0:8000", "--workers", "4"]

--- a/backend/core/views.py
+++ b/backend/core/views.py
@@ -383,7 +383,7 @@ class TaskStatusView(generics.GenericAPIView):
 
 
 @api_view(["GET"])
-@permission_classes([AllowAny])
+@permission_classes([IsAuthenticated])
 def celery_ping(request):
     """Check if the Celery worker is responsive."""
     try:
@@ -391,3 +391,5 @@ def celery_ping(request):
     except Exception:
         return Response(status=status.HTTP_503_SERVICE_UNAVAILABLE)
     return Response({"status": "ok"})
+
+celery_ping.throttle_scope = "celery_ping"

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -38,3 +38,4 @@ isort==6.0.1
 flake8==7.2.0
 django-ratelimit==4.1.0
 django-debug-toolbar==4.3.0
+gunicorn==21.2.0

--- a/backend/server/settings.py
+++ b/backend/server/settings.py
@@ -152,6 +152,7 @@ REST_FRAMEWORK = {
         "anon": "20/min",
         "user": "100/min",
         "dj_rest_auth": "3/min",
+        "celery_ping": "10/min",
     },
 }
 
@@ -161,7 +162,7 @@ SIMPLE_JWT = {
     "BLACKLIST_AFTER_ROTATION": True,
 }
 
-CORS_ALLOW_ALL_ORIGINS = True
+CORS_ALLOWED_ORIGINS = env("ALLOWED_ORIGINS", "").split(",")
 
 
 # Configure django-allauth for username/email login without warnings.
@@ -189,3 +190,12 @@ REST_AUTH_SERIALIZERS = {
     "LOGIN_SERIALIZER": "accounts.serializers.NoWarnLoginSerializer"
 }
 ACCOUNT_EMAIL_VERIFICATION = "none"
+
+if not DEBUG:
+    SECURE_SSL_REDIRECT = True
+    SESSION_COOKIE_SECURE = True
+    CSRF_COOKIE_SECURE = True
+    SECURE_HSTS_SECONDS = 63072000
+    SECURE_HSTS_INCLUDE_SUBDOMAINS = True
+    SECURE_HSTS_PRELOAD = True
+    SECURE_REFERRER_POLICY = "same-origin"

--- a/deploy/nginx.conf
+++ b/deploy/nginx.conf
@@ -1,0 +1,26 @@
+worker_processes 1;
+
+events { }
+
+http {
+    server {
+        listen 80;
+        return 301 https://$host$request_uri;
+    }
+
+    server {
+        listen 443 ssl;
+        ssl_certificate /etc/ssl/certs/ssl-cert-snakeoil.pem;
+        ssl_certificate_key /etc/ssl/private/ssl-cert-snakeoil.key;
+
+        location / {
+            proxy_pass http://web:8000;
+            proxy_set_header Host $host;
+            proxy_set_header X-Real-IP $remote_addr;
+            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+            proxy_set_header X-Forwarded-Proto $scheme;
+        }
+
+        add_header Strict-Transport-Security "max-age=63072000; includeSubDomains; preload" always;
+    }
+}

--- a/deploy/tests/test_prod_settings.py
+++ b/deploy/tests/test_prod_settings.py
@@ -1,0 +1,14 @@
+from django.test import SimpleTestCase, override_settings
+from django.conf import settings
+
+
+class ProdSecuritySettingsTest(SimpleTestCase):
+    @override_settings(DEBUG=False)
+    def test_secure_settings_enabled(self):
+        self.assertTrue(settings.SECURE_SSL_REDIRECT)
+        self.assertTrue(settings.SESSION_COOKIE_SECURE)
+        self.assertTrue(settings.CSRF_COOKIE_SECURE)
+        self.assertEqual(settings.SECURE_HSTS_SECONDS, 63072000)
+        self.assertTrue(settings.SECURE_HSTS_INCLUDE_SUBDOMAINS)
+        self.assertTrue(settings.SECURE_HSTS_PRELOAD)
+        self.assertEqual(settings.SECURE_REFERRER_POLICY, "same-origin")

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -1,0 +1,25 @@
+version: "3.9"
+services:
+  web:
+    build: ./backend
+    command: gunicorn server.wsgi:application -b 0.0.0.0:8000 --workers 4
+    env_file: backend/.env
+    depends_on:
+      - redis
+  redis:
+    image: redis:7
+  worker:
+    build: ./backend
+    command: celery -A server worker -l info
+    env_file: backend/.env
+    depends_on:
+      - redis
+  nginx:
+    image: nginx:1.25
+    volumes:
+      - ./deploy/nginx.conf:/etc/nginx/nginx.conf
+    ports:
+      - "80:80"
+      - "443:443"
+    depends_on:
+      - web

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -1,0 +1,10 @@
+# Production Deployment
+
+1. Create a `.env` in `backend/` with all required secrets. See `.env.sample` for keys.
+2. Build and start the stack:
+
+```bash
+docker compose -f docker-compose.prod.yml up -d
+```
+
+This launches Gunicorn, Celery, Redis and Nginx. Nginx forwards HTTPS traffic to the `web` service and enforces HSTS. Access the app at `https://localhost` (accept the self‑signed cert in a browser).


### PR DESCRIPTION
## Summary
- add production Docker Compose setup with nginx, gunicorn and worker
- harden Django settings for HTTPS and scoped CORS
- secure the celery ping endpoint and throttle usage
- create smoke tests for prod settings
- document deployment and show Docker build status

## Testing
- `make test-backend`
- `make lint-backend` *(fails: F401 unused imports)*

------
https://chatgpt.com/codex/tasks/task_e_68559042c330832389fb126be6c9826e